### PR TITLE
회원가입 & 로그인 관련 API _ ver2

### DIFF
--- a/src/main/java/com/planz/planit/config/BaseResponseStatus.java
+++ b/src/main/java/com/planz/planit/config/BaseResponseStatus.java
@@ -88,6 +88,7 @@ public enum BaseResponseStatus {
     FAIL_WITHDRAWAL(false, 6025, "User 테이블에서 해당 정보를 삭제하는데 실패했습니다."),
     INVALID_PASSWORD(false, 6026, "비밀번호가 일치하지 않습니다."),
     NOT_EXIST_PASSWORD(false, 6027, "비밀번호를 입력해주세요."),
+    TWO_REFRESH_TOKEN_NOT_EQUAL(false, 6028, "헤더의 refresh token과 서버에 저장된 refresh token이 일치하지 않습니다.")
     ;
 
 

--- a/src/main/java/com/planz/planit/config/BaseResponseStatus.java
+++ b/src/main/java/com/planz/planit/config/BaseResponseStatus.java
@@ -88,7 +88,10 @@ public enum BaseResponseStatus {
     FAIL_WITHDRAWAL(false, 6025, "User 테이블에서 해당 정보를 삭제하는데 실패했습니다."),
     INVALID_PASSWORD(false, 6026, "비밀번호가 일치하지 않습니다."),
     NOT_EXIST_PASSWORD(false, 6027, "비밀번호를 입력해주세요."),
-    TWO_REFRESH_TOKEN_NOT_EQUAL(false, 6028, "헤더의 refresh token과 서버에 저장된 refresh token이 일치하지 않습니다.")
+    TWO_REFRESH_TOKEN_NOT_EQUAL(false, 6028, "헤더의 refresh token과 서버에 저장된 refresh token이 일치하지 않습니다."),
+    NOT_EXIST_OLD_PASSWORD(false, 6029, "기존 비밀번호를 입력해주세요."),
+    NOT_EXIST_NEW_PASSWORD(false, 6030, "새로운 비밀번호를 입력해주세요."),
+    NOT_EXIST_NICKNAME(false, 6031, "새로운 닉네임을 입력해주세요.")
     ;
 
 

--- a/src/main/java/com/planz/planit/config/security/WebSecurityConfig.java
+++ b/src/main/java/com/planz/planit/config/security/WebSecurityConfig.java
@@ -3,7 +3,9 @@ package com.planz.planit.config.security;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.planz.planit.config.security.filter.JwtAuthenticationFilter;
 import com.planz.planit.config.security.filter.JwtAuthorizationFilter;
+import com.planz.planit.src.domain.deviceToken.DeviceTokenRepository;
 import com.planz.planit.src.domain.user.UserRepository;
+import com.planz.planit.src.service.DeviceTokenService;
 import com.planz.planit.src.service.HttpResponseService;
 import com.planz.planit.src.service.JwtTokenService;
 import lombok.extern.log4j.Log4j2;
@@ -23,13 +25,17 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
     private final UserRepository userRepository;
     private final ObjectMapper objectMapper;
     private final HttpResponseService httpResponseService;
+    private final DeviceTokenService deviceTokenService;
+    private final DeviceTokenRepository deviceTokenRepository;
 
     @Autowired
-    public WebSecurityConfig(JwtTokenService jwtTokenService, UserRepository userRepository, ObjectMapper objectMapper, HttpResponseService httpResponseService) {
+    public WebSecurityConfig(JwtTokenService jwtTokenService, UserRepository userRepository, ObjectMapper objectMapper, HttpResponseService httpResponseService, DeviceTokenService deviceTokenService, DeviceTokenRepository deviceTokenRepository) {
         this.jwtTokenService = jwtTokenService;
         this.userRepository = userRepository;
         this.objectMapper = objectMapper;
         this.httpResponseService = httpResponseService;
+        this.deviceTokenService = deviceTokenService;
+        this.deviceTokenRepository = deviceTokenRepository;
     }
 
 
@@ -49,7 +55,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
                 .formLogin().disable()
                 .httpBasic().disable()  // rest api 만을 고려하여 기본 설정은 해제
-                .addFilter(new JwtAuthenticationFilter(authenticationManager(), jwtTokenService, objectMapper, httpResponseService))
+                .addFilter(new JwtAuthenticationFilter(authenticationManager(), jwtTokenService, objectMapper, httpResponseService, deviceTokenService, deviceTokenRepository))
                 .addFilter(new JwtAuthorizationFilter(authenticationManager(), jwtTokenService, userRepository, httpResponseService))
 
                 .authorizeRequests()    // 요청에 대한 사용권한 체크

--- a/src/main/java/com/planz/planit/config/security/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/planz/planit/config/security/filter/JwtAuthorizationFilter.java
@@ -46,7 +46,7 @@ public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
         log.info("요청 URI " + request.getRequestURI());
 
         // 회원가입 요청 or 액세스 토큰 재발급 요청 or 로그아웃 요청인 경우
-        if (request.getRequestURI().startsWith("/join") || request.getRequestURI().startsWith("/access-token") || request.getRequestURI().startsWith("/log-out")) {
+        if (request.getRequestURI().startsWith("/join") || request.getRequestURI().startsWith("/access-token") || request.getRequestURI().startsWith("/log-out") || request.getRequestURI().startsWith("/user/temporary/pwd")) {
             chain.doFilter(request, response);
             return;
         }

--- a/src/main/java/com/planz/planit/config/security/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/planz/planit/config/security/filter/JwtAuthorizationFilter.java
@@ -142,7 +142,7 @@ public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
             return null;
         }
 
-        User userEntity = userRepository.findByuserId(Long.valueOf(userPk)).orElse(null);
+        User userEntity = userRepository.findByUserId(Long.valueOf(userPk)).orElse(null);
 
         if (userEntity == null) {
             log.error("존재하지 않는 사용자입니다.");

--- a/src/main/java/com/planz/planit/src/apicontroller/UserController.java
+++ b/src/main/java/com/planz/planit/src/apicontroller/UserController.java
@@ -42,32 +42,30 @@ public class UserController {
 
     // 닉네임 형식 및 중복 확인
     @GetMapping("/join/dupli/nickname")
-    public BaseResponse<String> checkNickname(@RequestParam("nickname") String nickname){
+    public BaseResponse<String> checkNickname(@RequestParam("nickname") String nickname) {
 
-        if (ValidationRegex.isRegexNickname(nickname) == false){
+        if (ValidationRegex.isRegexNickname(nickname) == false) {
             return new BaseResponse<>(INVALID_NICKNAME_FORM);
         }
 
-        if(userService.isEmptyNickname(nickname)){
+        if (userService.isEmptyNickname(nickname)) {
             return new BaseResponse<>("사용가능한 닉네임입니다.");
-        }
-        else{
+        } else {
             return new BaseResponse<>(ALREADY_EXIST_NICKNAME);
         }
     }
 
     // 이메일 형식 및 중복 확인
     @GetMapping("/join/dupli/email")
-    public BaseResponse<String> checkEmail(@RequestParam("email") String email){
+    public BaseResponse<String> checkEmail(@RequestParam("email") String email) {
 
-        if(ValidationRegex.isRegexEmail(email) == false){
+        if (ValidationRegex.isRegexEmail(email) == false) {
             return new BaseResponse<>(INVALID_EMAIL_FORM);
         }
 
-        if(userService.isEmptyEmail(email)){
+        if (userService.isEmptyEmail(email)) {
             return new BaseResponse<>("사용가능한 이메일입니다.");
-        }
-        else{
+        } else {
             return new BaseResponse<>(ALREADY_EXIST_EMAIL);
         }
     }
@@ -75,18 +73,17 @@ public class UserController {
 
     @PostMapping("/join/auth/new-num")
     public BaseResponse<String> createAuthNum(@Valid @RequestBody CreateAuthNumReqDTO reqDTO,
-                                              BindingResult br){
+                                              BindingResult br) {
         // 형식적 validation
-        if(br.hasErrors()){
+        if (br.hasErrors()) {
             String errorName = br.getAllErrors().get(0).getDefaultMessage();
             return new BaseResponse<>(BaseResponseStatus.of(errorName));
         }
 
-        try{
+        try {
             userService.createAuthNum(reqDTO.getEmail());
             return new BaseResponse<>("해당 이메일로 인증번호를 발송했습니다.");
-        }
-        catch (BaseException e){
+        } catch (BaseException e) {
             return new BaseResponse<>(e.getStatus());
         }
 
@@ -94,18 +91,17 @@ public class UserController {
 
     @PostMapping("/join/auth/check-num")
     public BaseResponse<String> checkAuthNum(@Valid @RequestBody CheckAuthNumReqDTO reqDTO,
-                                             BindingResult br){
+                                             BindingResult br) {
         // 형식적 validation
-        if(br.hasErrors()){
+        if (br.hasErrors()) {
             String errorName = br.getAllErrors().get(0).getDefaultMessage();
             return new BaseResponse<>(BaseResponseStatus.of(errorName));
         }
 
-        try{
+        try {
             String result = userService.checkAuthNum(reqDTO.getEmail(), reqDTO.getAuthNum());
             return new BaseResponse<>(result);
-        }
-        catch (BaseException e){
+        } catch (BaseException e) {
             return new BaseResponse<>(e.getStatus());
         }
 
@@ -119,16 +115,15 @@ public class UserController {
         log.info("UserController.join() 호출");
 
         // 형식적 validation
-        if(br.hasErrors()){
+        if (br.hasErrors()) {
             String errorName = br.getAllErrors().get(0).getDefaultMessage();
             return new BaseResponse<>(BaseResponseStatus.of(errorName));
         }
 
-        try{
+        try {
             LoginResDTO result = userService.join(reqDTO, response);
             return new BaseResponse<>(result);
-        }
-        catch (BaseException e){
+        } catch (BaseException e) {
             return new BaseResponse<>(e.getStatus());
         }
     }
@@ -141,7 +136,7 @@ public class UserController {
                                                    BindingResult br) {
 
         // 형식적 validation => DTO 수정 필요
-        if(br.hasErrors()){
+        if (br.hasErrors()) {
             String errorName = br.getAllErrors().get(0).getDefaultMessage();
             return new BaseResponse<>(BaseResponseStatus.of(errorName));
         }
@@ -153,14 +148,13 @@ public class UserController {
             // 형식적 Validation
             ValidationUtils.checkUserIdInHeader(userId);
 
-            if(refreshToken == null){
+            if (refreshToken == null) {
                 return new BaseResponse<>(NOT_EXIST_REFRESH_TOKEN_IN_HEADER);
             }
 
             userService.reissueAccessToken(userId, refreshToken, reqDTO.getDeviceToken(), response);
             return new BaseResponse<>("JWT Access Token을 새로 발급했습니다.");
-        }
-        catch (BaseException e){
+        } catch (BaseException e) {
             return new BaseResponse<>(e.getStatus());
         }
     }
@@ -169,23 +163,22 @@ public class UserController {
     @PostMapping("/log-out")
     public BaseResponse<String> logout(HttpServletRequest request,
                                        @Valid @RequestBody DeviceTokenReqDTO reqDTO,
-                                       BindingResult br){
+                                       BindingResult br) {
         // 형식적 validation => DTO 수정 필요
-        if(br.hasErrors()){
+        if (br.hasErrors()) {
             String errorName = br.getAllErrors().get(0).getDefaultMessage();
             return new BaseResponse<>(BaseResponseStatus.of(errorName));
         }
 
         String userId = request.getHeader(USER_ID_HEADER_NAME);
 
-        try{
+        try {
             // 형식적 Validation
             ValidationUtils.checkUserIdInHeader(userId);
 
             userService.logout(userId, reqDTO);
             return new BaseResponse<>("로그아웃이 완료되었습니다. 클라이언트 단의 access token과 refresh token을 삭제해주세요.");
-        }
-        catch (BaseException e){
+        } catch (BaseException e) {
             return new BaseResponse<>(e.getStatus());
         }
     }
@@ -194,23 +187,22 @@ public class UserController {
     @DeleteMapping("/api/user")
     public BaseResponse<String> withdrawal(HttpServletRequest request,
                                            @Valid @RequestBody WithdrawalReqDTO reqDTO,
-                                           BindingResult br){
+                                           BindingResult br) {
 
         // 형식적 validation
-        if(br.hasErrors()){
+        if (br.hasErrors()) {
             String errorName = br.getAllErrors().get(0).getDefaultMessage();
             return new BaseResponse<>(BaseResponseStatus.of(errorName));
         }
 
         String userId = request.getHeader(USER_ID_HEADER_NAME);
 
-        try{
+        try {
             // Spring Security가 userId와 jwtAccessToken에 대한 validation 모두 완료!
 
             userService.withdrawal(userId, reqDTO.getPassword());
             return new BaseResponse<>("회원탈퇴가 완료되었습니다.");
-        }
-        catch (BaseException e){
+        } catch (BaseException e) {
             return new BaseResponse<>(e.getStatus());
         }
     }
@@ -218,21 +210,64 @@ public class UserController {
     // 임시 비밀번호 발송
     @PostMapping("/user/temporary/pwd")
     public BaseResponse<String> createTemporaryPwd(@Valid @RequestBody CreateTemporaryPwdReqDTO reqDTO,
-                                                   BindingResult br){
+                                                   BindingResult br) {
 
         // 형식적 validation
-        if(br.hasErrors()){
+        if (br.hasErrors()) {
             String errorName = br.getAllErrors().get(0).getDefaultMessage();
             return new BaseResponse<>(BaseResponseStatus.of(errorName));
         }
 
-        try{
+        try {
             userService.createTemporaryPwd(reqDTO.getEmail());
             return new BaseResponse<>("해당 이메일로 임시 비밀번호를 발송했습니다.");
-        }
-        catch (BaseException e){
+        } catch (BaseException e) {
             return new BaseResponse<>(e.getStatus());
         }
 
+    }
+
+    // 비밀번호 변경
+    @PatchMapping("/api/user/pwd")
+    public BaseResponse<String> modifyPassword(HttpServletRequest request,
+                                               @Valid @RequestBody ModifyPasswordReqDTO reqDTO,
+                                               BindingResult br) {
+        // 형식적 validation
+        if (br.hasErrors()) {
+            String errorName = br.getAllErrors().get(0).getDefaultMessage();
+            return new BaseResponse<>(BaseResponseStatus.of(errorName));
+        }
+
+        // 헤더에서 userId 가져오기
+        String userId = request.getHeader(USER_ID_HEADER_NAME);
+
+        try {
+            userService.modifyPassword(userId, reqDTO.getOldPassword(), reqDTO.getNewPassword());
+            return new BaseResponse<>("비밀번호 변경이 성공적으로 완료되었습니다.");
+        } catch (BaseException e) {
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
+
+    // 닉네임 변경
+    @PatchMapping("/api/user/nickname")
+    public BaseResponse<String> modifyNickname(HttpServletRequest request,
+                                               @Valid @RequestBody ModifyNicknameReqDTO reqDTO,
+                                               BindingResult br) {
+        // 형식적 validation
+        if (br.hasErrors()) {
+            String errorName = br.getAllErrors().get(0).getDefaultMessage();
+            return new BaseResponse<>(BaseResponseStatus.of(errorName));
+        }
+
+        // 헤더에서 userId 가져오기
+        String userId = request.getHeader(USER_ID_HEADER_NAME);
+
+        try {
+            userService.modifyNickname(userId, reqDTO.getNickname());
+            return new BaseResponse<>("닉네임 변경이 성공적으로 완료되었습니다.");
+        } catch (BaseException e) {
+            return new BaseResponse<>(e.getStatus());
+        }
     }
 }

--- a/src/main/java/com/planz/planit/src/apicontroller/UserController.java
+++ b/src/main/java/com/planz/planit/src/apicontroller/UserController.java
@@ -192,7 +192,16 @@ public class UserController {
 
     // 회원탈퇴
     @DeleteMapping("/api/user")
-    public BaseResponse<String> withdrawal(HttpServletRequest request, @Valid @RequestBody WithdrawalReqDTO reqDTO){
+    public BaseResponse<String> withdrawal(HttpServletRequest request,
+                                           @Valid @RequestBody WithdrawalReqDTO reqDTO,
+                                           BindingResult br){
+
+        // 형식적 validation
+        if(br.hasErrors()){
+            String errorName = br.getAllErrors().get(0).getDefaultMessage();
+            return new BaseResponse<>(BaseResponseStatus.of(errorName));
+        }
+
         String userId = request.getHeader(USER_ID_HEADER_NAME);
 
         try{
@@ -204,5 +213,26 @@ public class UserController {
         catch (BaseException e){
             return new BaseResponse<>(e.getStatus());
         }
+    }
+
+    // 임시 비밀번호 발송
+    @PostMapping("/user/temporary/pwd")
+    public BaseResponse<String> createTemporaryPwd(@Valid @RequestBody CreateTemporaryPwdReqDTO reqDTO,
+                                                   BindingResult br){
+
+        // 형식적 validation
+        if(br.hasErrors()){
+            String errorName = br.getAllErrors().get(0).getDefaultMessage();
+            return new BaseResponse<>(BaseResponseStatus.of(errorName));
+        }
+
+        try{
+            userService.createTemporaryPwd(reqDTO.getEmail());
+            return new BaseResponse<>("해당 이메일로 임시 비밀번호를 발송했습니다.");
+        }
+        catch (BaseException e){
+            return new BaseResponse<>(e.getStatus());
+        }
+
     }
 }

--- a/src/main/java/com/planz/planit/src/domain/user/User.java
+++ b/src/main/java/com/planz/planit/src/domain/user/User.java
@@ -76,6 +76,7 @@ public class User {
         this.lastCheckAt = LocalDateTime.now();
     }
 
+    // 디바이스 토큰 값
     @Transient
     private String deviceToken;
 

--- a/src/main/java/com/planz/planit/src/domain/user/User.java
+++ b/src/main/java/com/planz/planit/src/domain/user/User.java
@@ -87,4 +87,8 @@ public class User {
     public void setPassword(String password) {
         this.password = password;
     }
+
+    public void setNickname(String nickname) {
+        this.nickname = nickname;
+    }
 }

--- a/src/main/java/com/planz/planit/src/domain/user/User.java
+++ b/src/main/java/com/planz/planit/src/domain/user/User.java
@@ -83,4 +83,8 @@ public class User {
     public void setDeviceToken(String deviceToken) {
         this.deviceToken = deviceToken;
     }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
 }

--- a/src/main/java/com/planz/planit/src/domain/user/UserRepository.java
+++ b/src/main/java/com/planz/planit/src/domain/user/UserRepository.java
@@ -14,8 +14,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
 
     Optional<User> findByNickname(String nickname);
-
-    Optional<User> findByuserId(Long userId);
+    Optional<User> findByUserId(Long userId);
 
 
     @Transactional

--- a/src/main/java/com/planz/planit/src/domain/user/dto/CreateTemporaryPwdReqDTO.java
+++ b/src/main/java/com/planz/planit/src/domain/user/dto/CreateTemporaryPwdReqDTO.java
@@ -1,0 +1,22 @@
+package com.planz.planit.src.domain.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class CreateTemporaryPwdReqDTO {
+
+    @NotBlank(message = "NOT_EXIST_EMAIL")
+    @Size(max = 50, message = "INVALID_EMAIL_FORM")
+    @Pattern(regexp = "^[A-Za-z0-9._^%$~#+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,6}$", message = "INVALID_EMAIL_FORM")
+    private String email;
+}

--- a/src/main/java/com/planz/planit/src/domain/user/dto/ModifyNicknameReqDTO.java
+++ b/src/main/java/com/planz/planit/src/domain/user/dto/ModifyNicknameReqDTO.java
@@ -1,0 +1,23 @@
+package com.planz.planit.src.domain.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ModifyNicknameReqDTO {
+
+    @NotBlank(message = "NOT_EXIST_NICKNAME")
+    @Size(max = 20, message = "INVALID_NICKNAME_FORM")
+    @Pattern(regexp = "^[A-Za-z0-9ㄱ-ㅎ가-힣]{1,20}$", message = "INVALID_NICKNAME_FORM")
+    private String nickname;
+
+}

--- a/src/main/java/com/planz/planit/src/domain/user/dto/ModifyPasswordReqDTO.java
+++ b/src/main/java/com/planz/planit/src/domain/user/dto/ModifyPasswordReqDTO.java
@@ -1,0 +1,27 @@
+package com.planz.planit.src.domain.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ModifyPasswordReqDTO {
+
+    @NotBlank(message = "NOT_EXIST_OLD_PASSWORD")
+    @Size(min = 6, max = 15, message = "INVALID_PWD_FORM")
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{6,15}$", message = "INVALID_PWD_FORM")
+    private String oldPassword;
+
+    @NotBlank(message = "NOT_EXIST_NEW_PASSWORD")
+    @Size(min = 6, max = 15, message = "INVALID_PWD_FORM")
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{6,15}$", message = "INVALID_PWD_FORM")
+    private String newPassword;
+}

--- a/src/main/java/com/planz/planit/src/service/JwtTokenService.java
+++ b/src/main/java/com/planz/planit/src/service/JwtTokenService.java
@@ -97,7 +97,7 @@ public class JwtTokenService {
     }
 
     // jwt refresh Token 생성
-    public String createRefreshToken(String userPk){
+    public String createRefreshToken(String deviceTokenId){
         log.info("createRefreshToken() 호출");
 
         Date now = new Date();
@@ -110,7 +110,7 @@ public class JwtTokenService {
                 .compact();
 
         // redis 저장
-        redisService.setRefreshTokenInRedis(userPk, refreshToken, REFRESH_TOKEN_EXPIRE_TIME);
+        redisService.setRefreshTokenInRedis(deviceTokenId, refreshToken, REFRESH_TOKEN_EXPIRE_TIME);
 
         return refreshToken;
     }

--- a/src/main/java/com/planz/planit/src/service/RedisService.java
+++ b/src/main/java/com/planz/planit/src/service/RedisService.java
@@ -36,12 +36,21 @@ public class RedisService {
         return stringRedisTemplate.expire(key, expireTime, TimeUnit.MILLISECONDS);
     }
 
-    // refresh 토큰 가져오기
-    public String getRefreshTokenInRedis(String deviceTokenId){
+    // refresh 토큰 비교하기
+    public boolean compareRefreshTokenInRedis(String deviceTokenId, String refreshTokenInHeader){
         String key = REFRESH_PREFIX + deviceTokenId;
 
         // 해당 userPk로 발급받은 refresh 토큰이 없다면 null 리턴
-        return valueOperations.get(key);
+        String refreshTokenInRedis = valueOperations.get(key);
+        if (refreshTokenInRedis == null){
+            return false;
+        }
+        else if (refreshTokenInRedis.equals(refreshTokenInHeader)){
+            return true;
+        }
+        else{
+            return false;
+        }
     }
 
     // refresh 토큰 삭제하기

--- a/src/main/java/com/planz/planit/src/service/RedisService.java
+++ b/src/main/java/com/planz/planit/src/service/RedisService.java
@@ -30,23 +30,23 @@ public class RedisService {
     // 나중에 key값이 usrePK값이 아닌 DeviceToken 테이블 PK로 변경되야함!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
     // refresh 토큰 저장하기
-    public Boolean setRefreshTokenInRedis(String userPk, String refreshToken, Long expireTime){
-        String key = REFRESH_PREFIX + userPk;
+    public Boolean setRefreshTokenInRedis(String deviceTokenId, String refreshToken, Long expireTime){
+        String key = REFRESH_PREFIX + deviceTokenId;
         valueOperations.set(key, refreshToken);
         return stringRedisTemplate.expire(key, expireTime, TimeUnit.MILLISECONDS);
     }
 
     // refresh 토큰 가져오기
-    public String getRefreshTokenInRedis(String userPk){
-        String key = REFRESH_PREFIX + userPk;
+    public String getRefreshTokenInRedis(String deviceTokenId){
+        String key = REFRESH_PREFIX + deviceTokenId;
 
         // 해당 userPk로 발급받은 refresh 토큰이 없다면 null 리턴
         return valueOperations.get(key);
     }
 
     // refresh 토큰 삭제하기
-    public void deleteRefreshTokenInRedis(String userPk){
-        String key = REFRESH_PREFIX + userPk;
+    public void deleteRefreshTokenInRedis(String deviceTokenId){
+        String key = REFRESH_PREFIX + deviceTokenId;
         stringRedisTemplate.delete(key);
     }
 


### PR DESCRIPTION
### 1. 로그인 / 회원가입 시 디바이스 토큰 추가 
* 로그인 / 회원가입 시 디바이스 토큰을 추가하는 로직을 넣었다.

### 2. 로그아웃 / 회원탈퇴 시 디바이스 토큰 삭제
* 로그아웃 / 회원탈퇴 시 디바이스 토큰 삭제하는 로직을 넣었다.

### 3. Redis에 deviceTokenId를 key로 refresh token 저장
* 기존에는 userId를 key로 refresh token을 저장했다.
* 그러나 기기마다 refresh token 값이 다르므로, deviceTokenId를 key로 변경했다.

### 4. access token 재발급 API 수정
* 헤더에 담긴 refresh token과 서버의 redis에 저장된 refresh token을 비교하는 로직 추가

### 5. 임시 비밀번호 발송 API 
* request body에 담긴 email로 10자리 임시 비밀번호를 발송한다.
* 이미 존재하는 이메일이어야 한다.

### 6. 비밀번호 변경 API
* request body에 담긴 oldPassword와 현재 비밀번호를 비교해서 일치하면, 사용자의 비밀번호를 newPassword로 변경한다.

### 7. 닉네임 변경 API
* 존재하지 않는 새로운 닉네임으로 변경한다.