### PR TITLE
기타 API 구현 및 수정

### DIFF
--- a/src/main/java/com/planz/planit/config/BaseResponseStatus.java
+++ b/src/main/java/com/planz/planit/config/BaseResponseStatus.java
@@ -123,7 +123,11 @@ public enum BaseResponseStatus {
     NOT_EXIST_PLANET(false, 6118, "해당 유저의 행성을 찾을 수 없습니다."),
     NOT_EXIST_PROFILE_COLOR(false, 6119, "변경할 프로필 색상을 입력해주세요. (LightRed, Yellow, Green, SkyBlue, Blue, LightPurple, Purple, Pink, Gray, Black)"),
     INVALID_PROFILE_COLOR(false, 6120, "유효하지 않은 프로필 색상입니다. (LightRed, Yellow, Green, SkyBlue, Blue, LightPurple, Purple, Pink, Gray, Black)"),
-    NOT_FRIEND_RELATION(false, 6121, "서로 친구 관계가 아니기 때문에, 행성 메인 화면을 조회할 수 없습니다.")
+    NOT_FRIEND_RELATION(false, 6121, "서로 친구 관계가 아니기 때문에, 행성 메인 화면을 조회할 수 없습니다."),
+
+
+    // 설정 관련 BaseResponseStatus
+    INVALID_MISSION_STATUS(false, 6200, "유효하지 않은 status (path variable) 값 입니다. 0 (운영자 미션 안받기) 또는 1 (운영자 미션 받기)을 입력해주세요.")
     ;
 
 

--- a/src/main/java/com/planz/planit/src/apicontroller/PlanetController.java
+++ b/src/main/java/com/planz/planit/src/apicontroller/PlanetController.java
@@ -3,6 +3,7 @@ package com.planz.planit.src.apicontroller;
 import com.planz.planit.config.BaseException;
 import com.planz.planit.config.BaseResponse;
 import com.planz.planit.src.domain.planet.dto.GetPlanetMainInfoResDTO;
+import com.planz.planit.src.domain.planet.dto.GetPlanetMyInfoResDTO;
 import com.planz.planit.src.domain.user.User;
 import com.planz.planit.src.service.FriendService;
 import com.planz.planit.src.service.PlanetService;
@@ -61,6 +62,24 @@ public class PlanetController {
             }
 
             return new BaseResponse<>(planetService.getPlanetMainInfo(targetUserId));
+        }
+        catch (BaseException e){
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
+
+    /**
+     * 나의 행성 정보를 조회한다.
+     * @RequestHeader User-Id, Jwt-Access-Token
+     * @return 행성 나이, 행성 레벨, 보유 포인트, 평균 목표 완성률, 좋아요 받은 수, 좋아요 누른 수
+     */
+    @GetMapping("/my-info")
+    @ApiOperation("나의 행성 정보 조회 API")
+    public BaseResponse<GetPlanetMyInfoResDTO> getPlanetMyInfo(HttpServletRequest request){
+        Long userId = Long.valueOf(request.getHeader(USER_ID_HEADER_NAME));
+
+        try{
+            return new BaseResponse<>(planetService.getPlanetMyInfo(userId));
         }
         catch (BaseException e){
             return new BaseResponse<>(e.getStatus());

--- a/src/main/java/com/planz/planit/src/apicontroller/UserController.java
+++ b/src/main/java/com/planz/planit/src/apicontroller/UserController.java
@@ -394,4 +394,37 @@ public class UserController {
             return new BaseResponse<>(e.getStatus());
         }
     }
+
+
+    /**
+     * 운영자 미션 받기 여부를 변경한다.
+     * @RequestHeader User-Id, Jwt-Access-Token
+     * @PathVariable status
+     * @return 결과 메세지
+     */
+    @PatchMapping("/api/setting/operator-mission/{status}")
+    @ApiOperation("운영자 미션 받기 설정 API")
+    public BaseResponse<String> convertMissionStatus(HttpServletRequest request, @PathVariable int status){
+
+        // status에 대한 형식적 validation
+        if (status != 0 && status != 1){
+            return new BaseResponse<>(INVALID_MISSION_STATUS);
+        }
+
+        Long userId = Long.valueOf(request.getHeader(USER_ID_HEADER_NAME));
+
+        try{
+            userService.convertMissionStatus(userId, status);
+            if (status == 0){
+                return new BaseResponse<>("운영자 미션 받기를 비활성화했습니다.");
+            }
+            else{
+                return new BaseResponse<>("운영자 미션 받기를 활성화했습니다.");
+            }
+
+        }
+        catch (BaseException e){
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
 }

--- a/src/main/java/com/planz/planit/src/domain/item/ItemRepository.java
+++ b/src/main/java/com/planz/planit/src/domain/item/ItemRepository.java
@@ -12,8 +12,8 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
     @Query(value = "select i from Item i where i.itemId = :itemId and i.type = :type")
     Optional<Item> findItemByIdAndType(@Param("itemId") Long itemId, @Param("type") ItemType type);
 
-    @Query(value = "select i.itemId from Item i where i.type = :type and i.price > 0")
-    List<Long> findStoreItemIdsByType(@Param("type") ItemType type);
+    @Query(value = "select i from Item i where i.type = :type and i.price > 0")
+    List<Item> findStoreItemsByType(@Param("type") ItemType type);
 
     @Override
     Optional<Item> findById(Long itemId);

--- a/src/main/java/com/planz/planit/src/domain/planet/dto/GetPlanetMyInfoResDTO.java
+++ b/src/main/java/com/planz/planit/src/domain/planet/dto/GetPlanetMyInfoResDTO.java
@@ -1,0 +1,27 @@
+package com.planz.planit.src.domain.planet.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GetPlanetMyInfoResDTO {
+
+    // 행성 나이
+    private long age;
+
+    // 행성 레벨
+    private int level;
+
+    // 보유 포인트
+    private int point;
+
+    // 평균 목표 완성률
+    private int avgGoalCompleteRate;
+
+    // 좋아요 받은 수
+    private int getFavoriteCount;
+
+    // 좋아요 누른 수
+    private int putFavoriteCount;
+}

--- a/src/main/java/com/planz/planit/src/domain/user/User.java
+++ b/src/main/java/com/planz/planit/src/domain/user/User.java
@@ -102,4 +102,8 @@ public class User {
     public void setProfileColor(UserProfileColor profileColor) {
         this.profileColor = profileColor;
     }
+
+    public void setMissionStatus(Integer missionStatus) {
+        this.missionStatus = missionStatus;
+    }
 }

--- a/src/main/java/com/planz/planit/src/service/ItemService.java
+++ b/src/main/java/com/planz/planit/src/service/ItemService.java
@@ -16,6 +16,7 @@ import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static com.planz.planit.config.BaseResponseStatus.*;
@@ -53,8 +54,21 @@ public class ItemService {
             User user = userService.findUser(userId);
 
             // 2. 아이템 목록 조회
-            List<Long> characterItemIdList = findStoreItemIdsByType(ItemType.CHARACTER_ITEM);
-            List<Long> planetItemIdList = findStoreItemIdsByType(ItemType.PLANET_ITEM);
+            List<Long> characterItemIdList = new ArrayList<>();
+            List<Item> characterItemList = findStoreItemsByType(ItemType.CHARACTER_ITEM);
+            for (Item item : characterItemList) {
+                if(calculateMaxCnt(user, item) > 0){
+                    characterItemIdList.add(item.getItemId());
+                }
+            }
+
+            List<Long> planetItemIdList = new ArrayList<>();
+            List<Item> planetItemList = findStoreItemsByType(ItemType.PLANET_ITEM);
+            for (Item item : planetItemList) {
+                if(calculateMaxCnt(user, item) > 0){
+                    planetItemIdList.add(item.getItemId());
+                }
+            }
 
             // 3. GetItemStoreInfoResDTO 반환
             return GetItemStoreInfoResDTO.builder()
@@ -74,13 +88,13 @@ public class ItemService {
      * 아이템 타입(PlanetItem / CharacterItem) 별로 스토어에서 판매중인 itemId 리스트를 반환한다.
      * 스토어에서 판매중인 아이템은 가격이 1원 이상이다.
      */
-    public List<Long> findStoreItemIdsByType(ItemType type) throws BaseException {
+    public List<Item> findStoreItemsByType(ItemType type) throws BaseException {
 
         try{
-            return itemRepository.findStoreItemIdsByType(type);
+            return itemRepository.findStoreItemsByType(type);
         }
         catch (Exception e){
-            log.error("findItemIdsByType() : itemRepository.findItemIdsByType(type) 실행 중 데이터베이스 에러 발생");
+            log.error("findStoreItemsByType() : itemRepository.findStoreItemsByType(type) 실행 중 데이터베이스 에러 발생");
             e.printStackTrace();
             throw new BaseException(DATABASE_ERROR);
         }

--- a/src/main/java/com/planz/planit/src/service/PlanetService.java
+++ b/src/main/java/com/planz/planit/src/service/PlanetService.java
@@ -8,11 +8,14 @@ import com.planz.planit.src.domain.inventory.dto.PositionDTO;
 import com.planz.planit.src.domain.planet.Planet;
 import com.planz.planit.src.domain.planet.PlanetRepository;
 import com.planz.planit.src.domain.planet.dto.GetPlanetMainInfoResDTO;
+import com.planz.planit.src.domain.planet.dto.GetPlanetMyInfoResDTO;
 import com.planz.planit.src.domain.user.User;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -132,6 +135,49 @@ public class PlanetService {
                     .build();
 
         } catch (BaseException e) {
+            throw e;
+        }
+    }
+
+    /**
+     * 나의 행성 정보 조회 API
+     * (행성 나이, 행성 레벨, 보유 포인트, 평균 목표 완성률, 좋아요 받은 수, 좋아요 누른 수) 반환
+     * 1. 유저 조회
+     * 2. 행성 조회
+     * 3. 행성 나이 계산
+     * 4. 평균 목표 완성률 계산
+     * 5. 좋아요 받은 수 계산
+     * 6. 좋아요 누른 수 계산
+     */
+    public GetPlanetMyInfoResDTO getPlanetMyInfo(Long userId) throws BaseException{
+        try {
+            // 1. 유저 조회
+            User user = userService.findUser(userId);
+
+            // 2. 행성 조회
+            Planet planet = user.getPlanet();
+
+            // 3. 행성 나이 계산
+            LocalDateTime today = LocalDateTime.now();
+            LocalDateTime createAt = user.getCreateAt();
+            long age = ChronoUnit.DAYS.between(createAt, today) + 1;
+
+            // 4. 평균 목표 완성률 계산
+
+            // 5. 좋아요 받은 수 계산
+
+            // 6. 좋아요 누른 수 계산
+
+            return GetPlanetMyInfoResDTO.builder()
+                    .age(age)
+                    .level(planet.getLevel())
+                    .point(user.getPoint())
+                    .avgGoalCompleteRate(0)
+                    .getFavoriteCount(0)
+                    .putFavoriteCount(0)
+                    .build();
+        }
+        catch (BaseException e){
             throw e;
         }
     }

--- a/src/main/java/com/planz/planit/src/service/UserService.java
+++ b/src/main/java/com/planz/planit/src/service/UserService.java
@@ -132,7 +132,7 @@ public class UserService {
             // 5. Planet 테이블 insert
             Planet planetEntity = Planet.builder()
                     .user(userEntity)
-                    .level(0)
+                    .level(1)
                     .exp(0)
                     .color(PlanetColor.valueOf(reqDTO.getPlanetColor()))
                     .build();

--- a/src/main/java/com/planz/planit/src/service/UserService.java
+++ b/src/main/java/com/planz/planit/src/service/UserService.java
@@ -611,4 +611,27 @@ public class UserService {
     }
 
 
+    /**
+     * 운영자 미션 받기 설정 API
+     * 운영자 미션 받기 여부를 변경한다.
+     * 1. 유저 찾기
+     * 2. 해당 유저의 missionStatus 값 변경
+     * 3. 다시 저장
+     */
+    public void convertMissionStatus(Long userId, int status) throws BaseException{
+
+        try{
+            // 1. 유저 찾기
+            User user = findUser(userId);
+
+            // 2. 해당 유저의 missionStatus 값 변경
+            user.setMissionStatus(status);
+
+            // 3. 다시 저장
+            saveUser(user);
+        }
+        catch (BaseException e){
+            throw e;
+        }
+    }
 }


### PR DESCRIPTION
### 나의 행성 정보 조회 API 구현
* 행성 나이, 행성 레벨, 보유 포인트, 평균 목표 완성률, 좋아요 받은 수, 좋아요 누른 수 반환.
* 목표 및 투두 API 완성 후, 평균 목표 완성률을 계산하는 로직을 추가해야 함!!
* 좋아요 API 완성 후,  좋아요 받은 수와 누른 수를 계산하는 로직을 추가해야 함!!

### 운영자 미션 받기 설정 API 구현
* 해당 API 호출 시, Users 테이블의 mission_status 필드 값 변경.

### 최초 회원가입 시, 행성 레벨을 1로 초기화
* 기존에는 최초 회원가입 시, 행성 레벨이 0으로 초기화 되었음.
* 회원가입 시, 행성 레벨이 1로 초기화되도록 수정.