### PR TITLE
공지사항 API 구현 및 아이템 API 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,10 @@ dependencies {
 
 	//okhttp
 	implementation group: 'com.squareup.okhttp3', name: 'okhttp', version: '4.9.1'
+
+	// deserialize
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+	implementation 'com.fasterxml.jackson.core:jackson-databind'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/planz/planit/config/BaseResponseStatus.java
+++ b/src/main/java/com/planz/planit/config/BaseResponseStatus.java
@@ -157,9 +157,13 @@ public enum BaseResponseStatus {
 
 
     // 설정 관련 BaseResponseStatus
-    INVALID_MISSION_STATUS(false, 6200, "유효하지 않은 status (path variable) 값 입니다. 0 (운영자 미션 안받기) 또는 1 (운영자 미션 받기)을 입력해주세요.")
-    ;
+    INVALID_MISSION_STATUS(false, 6200, "유효하지 않은 status (path variable) 값 입니다. 0 (운영자 미션 안받기) 또는 1 (운영자 미션 받기)을 입력해주세요."),
 
+
+    // 공지사항 관련 BaseResponseStatus
+    NOT_EXIST_NOTICE_TITLE(false, 6300, "공지사항 title 을 입력해주세요."),
+    NOT_EXIST_NOTICE_CONTENT(false, 6301, "공지사항 content 를 입력해주세요.")
+    ;
 
     private final boolean isSuccess;
     private final int code;

--- a/src/main/java/com/planz/planit/config/security/WebSecurityConfig.java
+++ b/src/main/java/com/planz/planit/config/security/WebSecurityConfig.java
@@ -59,7 +59,8 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .addFilter(new JwtAuthorizationFilter(authenticationManager(), jwtTokenService, userRepository, httpResponseService))
 
                 .authorizeRequests()    // 요청에 대한 사용권한 체크
-                .antMatchers("/api/**").access("hasRole('ROLE_USER')")
+                .antMatchers("/api/**").access("hasRole('ROLE_USER') or hasRole('ROLE_ADMIN')")
+                .antMatchers("/admin/api/notices/new-notice").access("hasRole('ROLE_ADMIN')")
                 .anyRequest().permitAll();
     }
 }

--- a/src/main/java/com/planz/planit/src/apicontroller/InventoryController.java
+++ b/src/main/java/com/planz/planit/src/apicontroller/InventoryController.java
@@ -38,11 +38,11 @@ public class InventoryController {
      * 카테고리 별로 인벤토리에서 보유 중인 행성 아이템 목록을 반환한다.
      * @RequestHeader User-Id, Jwt-Access-Token
      * @PathVariable category
-     * @return List(itemId, totalCount, placedCount, remainingCount)
+     * @return totalInventoryItemCount, List(itemId, totalCount, placedCount, remainingCount)
      */
     @GetMapping("/planet-items/{category}")
     @ApiOperation(value = "보유한 행성 아이템 목록 조회 API")
-    public BaseResponse<List<GetInventoryResDTO>> getInventoryByCategory(HttpServletRequest request, @PathVariable String category) {
+    public BaseResponse<GetInventoryResDTO> getInventoryByCategory(HttpServletRequest request, @PathVariable String category) {
 
         // 형식적 validation
         if (!ValidationRegex.isRegexInventoryCategory(category)) {
@@ -52,8 +52,7 @@ public class InventoryController {
         String userId = request.getHeader(USER_ID_HEADER_NAME);
 
         try {
-            List<GetInventoryResDTO> result = inventoryService.getInventoryByCategory(Long.valueOf(userId), category);
-            return new BaseResponse<>(result);
+            return new BaseResponse<>(inventoryService.getInventoryByCategory(Long.valueOf(userId), category));
         } catch (BaseException e) {
             return new BaseResponse<>(e.getStatus());
         }

--- a/src/main/java/com/planz/planit/src/apicontroller/NoticeController.java
+++ b/src/main/java/com/planz/planit/src/apicontroller/NoticeController.java
@@ -1,0 +1,68 @@
+package com.planz.planit.src.apicontroller;
+
+import com.planz.planit.config.BaseException;
+import com.planz.planit.config.BaseResponse;
+import com.planz.planit.config.BaseResponseStatus;
+import com.planz.planit.src.domain.notice.dto.CreateNoticeReqDTO;
+import com.planz.planit.src.domain.notice.dto.GetNoticesResDTO;
+import com.planz.planit.src.service.NoticeService;
+import io.swagger.annotations.ApiOperation;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+@RestController
+public class NoticeController {
+
+    private final NoticeService noticeService;
+
+    @Autowired
+    public NoticeController(NoticeService noticeService) {
+        this.noticeService = noticeService;
+    }
+
+    /**
+     * 새로운 공지사항을 생성한다.
+     * Users 테이블의 role 필드값이 "ROLE_ADMIN"인 사용자만 해당 API를 이용할 수 있다.
+     * @RequestHeader User-Id, Jwt-Access-Token
+     * @RequestBody title, content
+     * @return 결과 메세지
+     */
+    @PostMapping("/admin/api/notices/new-notice")
+    @ApiOperation(value = "공지사항 생성 API (ROLE_ADMIN 권한을 가진 사용자만 이용 가능)")
+    public BaseResponse<String> createNotice(@Valid @RequestBody CreateNoticeReqDTO reqDTO,
+                                             BindingResult br){
+
+        if(br.hasErrors()){
+            String errorName = br.getAllErrors().get(0).getDefaultMessage();
+            return new BaseResponse<>(BaseResponseStatus.of(errorName));
+        }
+
+        try {
+            noticeService.createNotice(reqDTO.getTitle(), reqDTO.getContent());
+            return new BaseResponse<>("성공적으로 새로운 공지사항을 생성했습니다.");
+        }
+        catch (BaseException e){
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
+
+    /**
+     * 모든 공지사항을 조회한다.
+     * @RequestHeader User-Id, Jwt-Access-Token
+     * @return
+     */
+    @GetMapping("/api/notices")
+    @ApiOperation(value = "공지사항 조회 API")
+    public BaseResponse<GetNoticesResDTO> getNotices(){
+
+        try{
+            return new BaseResponse<>(noticeService.getNotices());
+        }
+        catch (BaseException e){
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
+}

--- a/src/main/java/com/planz/planit/src/apicontroller/NoticeController.java
+++ b/src/main/java/com/planz/planit/src/apicontroller/NoticeController.java
@@ -52,7 +52,7 @@ public class NoticeController {
     /**
      * 모든 공지사항을 조회한다.
      * @RequestHeader User-Id, Jwt-Access-Token
-     * @return
+     * @return totalNoticeCnt, List(noticeId, title, content, createAt)
      */
     @GetMapping("/api/notices")
     @ApiOperation(value = "공지사항 조회 API")

--- a/src/main/java/com/planz/planit/src/domain/inventory/InventoryRepository.java
+++ b/src/main/java/com/planz/planit/src/domain/inventory/InventoryRepository.java
@@ -15,6 +15,8 @@ public interface InventoryRepository extends JpaRepository<Inventory, Long> {
     @Query("select i from Inventory i where i.user.userId = :userId and i.planetItem.category = :category")
     List<Inventory> findInventoryItemsByCategory(@Param("userId") Long userId, @Param("category") ItemCategory category);
 
+    @Query("select sum(i.count) from Inventory i where i.user.userId = :userId and i.planetItem.category <> :category ")
+    Integer countTotalInventoriesExcludeCategory(@Param("userId") Long userId, @Param("category") ItemCategory category);
 
     Optional<Inventory> findByUserAndPlanetItem(User user, Item planetItem);
 

--- a/src/main/java/com/planz/planit/src/domain/inventory/dto/GetInventoryResDTO.java
+++ b/src/main/java/com/planz/planit/src/domain/inventory/dto/GetInventoryResDTO.java
@@ -3,18 +3,30 @@ package com.planz.planit.src.domain.inventory.dto;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.List;
+
 @Getter
 @Builder
 public class GetInventoryResDTO {
 
-    private String itemCode;
+    // 인벤에 있는 전체 아이템 개수 (기본 아이템 제외)
+    private int totalInventoryItemCount;
 
-    // 보유 중인 아이템 전체 개수
-    private int totalCount;
+    private List<InventoryDTO> inventoryList;
 
-    // 행성에 배치된 아이템 개수
-    private int placedCount;
 
-    // 엔벤토리에 남아있는 아이템 개수
-    private int remainingCount;
+    @Getter
+    @Builder
+    public static class InventoryDTO{
+        private String itemCode;
+
+        // 보유 가능한 개수 (아이템 시트에 설정된 최대 보유 개수)
+        private int totalCount;
+
+        // 행성에 배치된 아이템 개수
+        private int placedCount;
+
+        // 현재 보유 중인 아이템 전체 개수
+        private int remainingCount;
+    }
 }

--- a/src/main/java/com/planz/planit/src/domain/notice/Notice.java
+++ b/src/main/java/com/planz/planit/src/domain/notice/Notice.java
@@ -1,0 +1,33 @@
+package com.planz.planit.src.domain.notice;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Notice {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notice_id")
+    private Long noticeId;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Column(name = "create_at")
+    @Builder.Default
+    private LocalDateTime createAt = LocalDateTime.now();
+
+}

--- a/src/main/java/com/planz/planit/src/domain/notice/NoticeRepository.java
+++ b/src/main/java/com/planz/planit/src/domain/notice/NoticeRepository.java
@@ -1,0 +1,8 @@
+package com.planz.planit.src.domain.notice;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+public interface NoticeRepository extends JpaRepository<Notice, Long> {
+
+}

--- a/src/main/java/com/planz/planit/src/domain/notice/dto/CreateNoticeReqDTO.java
+++ b/src/main/java/com/planz/planit/src/domain/notice/dto/CreateNoticeReqDTO.java
@@ -1,0 +1,20 @@
+package com.planz.planit.src.domain.notice.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CreateNoticeReqDTO {
+
+    @NotBlank(message = "NOT_EXIST_NOTICE_TITLE")
+    private String title;
+
+    @NotBlank(message = "NOT_EXIST_NOTICE_CONTENT")
+    private String content;
+
+}

--- a/src/main/java/com/planz/planit/src/domain/notice/dto/GetNoticesResDTO.java
+++ b/src/main/java/com/planz/planit/src/domain/notice/dto/GetNoticesResDTO.java
@@ -1,0 +1,35 @@
+package com.planz.planit.src.domain.notice.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class GetNoticesResDTO {
+
+    private int totalNoticeCnt;
+    private List<NoticeDTO> noticeList;
+
+
+    @Builder
+    @Getter
+    public static class NoticeDTO{
+        private Long noticeId;
+        private String title;
+        private String content;
+
+        // 자바 클래스 -> json 으로 serialize할 때 문제가 생기므로 추가
+        @JsonSerialize(using = LocalDateTimeSerializer.class)
+        @JsonFormat(pattern = "yyyy-MM-dd kk:mm:ss")
+        private LocalDateTime createAt;
+    }
+}
+

--- a/src/main/java/com/planz/planit/src/domain/user/UserRole.java
+++ b/src/main/java/com/planz/planit/src/domain/user/UserRole.java
@@ -1,5 +1,5 @@
 package com.planz.planit.src.domain.user;
 
 public enum UserRole {
-    ROLE_USER
+    ROLE_USER, ROLE_ADMIN
 }

--- a/src/main/java/com/planz/planit/src/service/NoticeService.java
+++ b/src/main/java/com/planz/planit/src/service/NoticeService.java
@@ -27,19 +27,30 @@ public class NoticeService {
     }
 
 
+    /**
+     * 공지사항 생성 API (ROLE_ADMIN 권한을 가진 사용자만 이용 가능)
+     * 1. Notice 엔티티 생성
+     * 2. Notice 엔티티 저장
+     */
     public void createNotice(String title, String content) throws BaseException {
 
         try {
+            // 1. Notice 엔티티 생성
             Notice notice = Notice.builder()
                     .title(title)
                     .content(content)
                     .build();
+
+            // 2. Notice 엔티티 저장
             saveNotice(notice);
         } catch (BaseException e) {
             throw e;
         }
     }
 
+    /**
+     * Notice 저장 혹은 업데이트
+     */
     public void saveNotice(Notice noticeEntity) throws BaseException {
         try {
             noticeRepository.save(noticeEntity);
@@ -50,10 +61,17 @@ public class NoticeService {
         }
     }
 
+    /**
+     * 공지사항 조회 API
+     * 1. 모든 공지사항 리스트를 생성일의 내림차순으로 정렬하여 조회하기
+     * 2. 결과 반환
+     */
     public GetNoticesResDTO getNotices() throws BaseException {
         try {
+            // 1. 모든 공지사항 리스트를 생성일의 내림차순으로 정렬하여 조회하기
             List<Notice> result = findAllNoticesOrderByCreateAt();
 
+            // 2. 결과 반환
             List<GetNoticesResDTO.NoticeDTO> noticeList = result.stream().map(notice ->
                     GetNoticesResDTO.NoticeDTO.builder()
                             .noticeId(notice.getNoticeId())
@@ -62,8 +80,6 @@ public class NoticeService {
                             .createAt(notice.getCreateAt())
                             .build()
             ).collect(Collectors.toList());
-
-            log.info("여기까지 문제없나? " + noticeList.get(0).getCreateAt());
 
             return GetNoticesResDTO.builder()
                     .totalNoticeCnt(noticeList.size())
@@ -74,6 +90,9 @@ public class NoticeService {
         }
     }
 
+    /**
+     * DB에서 생성일의 내림차순으로 정렬하여, 모든 공지사항 리스트 조회해오기
+     */
     public List<Notice> findAllNoticesOrderByCreateAt() throws BaseException {
         try {
             // 자바 클래스의 필드명 입력

--- a/src/main/java/com/planz/planit/src/service/NoticeService.java
+++ b/src/main/java/com/planz/planit/src/service/NoticeService.java
@@ -1,0 +1,89 @@
+package com.planz.planit.src.service;
+
+import com.planz.planit.config.BaseException;
+import com.planz.planit.config.BaseResponseStatus;
+import com.planz.planit.src.domain.notice.Notice;
+import com.planz.planit.src.domain.notice.NoticeRepository;
+import com.planz.planit.src.domain.notice.dto.GetNoticesResDTO;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.planz.planit.config.BaseResponseStatus.DATABASE_ERROR;
+
+@Service
+@Log4j2
+public class NoticeService {
+
+    private final NoticeRepository noticeRepository;
+
+    @Autowired
+    public NoticeService(NoticeRepository noticeRepository) {
+        this.noticeRepository = noticeRepository;
+    }
+
+
+    public void createNotice(String title, String content) throws BaseException {
+
+        try {
+            Notice notice = Notice.builder()
+                    .title(title)
+                    .content(content)
+                    .build();
+            saveNotice(notice);
+        } catch (BaseException e) {
+            throw e;
+        }
+    }
+
+    public void saveNotice(Notice noticeEntity) throws BaseException {
+        try {
+            noticeRepository.save(noticeEntity);
+        } catch (Exception e) {
+            log.error("saveNotice() : noticeRepository.save(noticeEntity) 실행 중 데이터베이스 에러 발생");
+            e.printStackTrace();
+            throw new BaseException(DATABASE_ERROR);
+        }
+    }
+
+    public GetNoticesResDTO getNotices() throws BaseException {
+        try {
+            List<Notice> result = findAllNoticesOrderByCreateAt();
+
+            List<GetNoticesResDTO.NoticeDTO> noticeList = result.stream().map(notice ->
+                    GetNoticesResDTO.NoticeDTO.builder()
+                            .noticeId(notice.getNoticeId())
+                            .title(notice.getTitle())
+                            .content(notice.getContent())
+                            .createAt(notice.getCreateAt())
+                            .build()
+            ).collect(Collectors.toList());
+
+            log.info("여기까지 문제없나? " + noticeList.get(0).getCreateAt());
+
+            return GetNoticesResDTO.builder()
+                    .totalNoticeCnt(noticeList.size())
+                    .noticeList(noticeList)
+                    .build();
+        } catch (BaseException e) {
+            throw e;
+        }
+    }
+
+    public List<Notice> findAllNoticesOrderByCreateAt() throws BaseException {
+        try {
+            // 자바 클래스의 필드명 입력
+            return noticeRepository.findAll(Sort.by(Sort.Direction.DESC, "createAt"));
+        } catch (Exception e) {
+            log.error("findAllNoticesOrderByCreateAt() : noticeRepository.findAll(Sort sort) 실행 중 데이터베이스 에러 발생");
+            e.printStackTrace();
+            throw new BaseException(DATABASE_ERROR);
+        }
+    }
+
+
+}

--- a/src/main/java/com/planz/planit/src/service/UserService.java
+++ b/src/main/java/com/planz/planit/src/service/UserService.java
@@ -91,7 +91,7 @@ public class UserService {
      * 4. DeviceToken 테이블 insert
      * 5. Planet 테이블 insert
      * 6-1. Inventory 테이블에 기본 행성 아이템(집, 포탈) insert
-     * 6-2. 포탈 : (-3.82, 4.8), 집 : (3.73, 5.2) 배치
+     * 6-2. 포탈 : (-3.82, 3.8), 집 : (3.73, 3.29) 배치
      * 7. Closet 테이블에 기본 캐릭터 아이템(기본 옷) insert
      * 8. access token, refresh token 생성해서 헤더에 담기
      */
@@ -141,7 +141,7 @@ public class UserService {
 
 
             /// 6-1. Inventory 테이블에 기본 행성 아이템(집, 포탈) insert
-            // 6-2. 포탈 : (-3.82, 4.8), 집 : (3.73, 5.2) 배치
+            // 6-2. 포탈 : (-3.82, 3.8), 집 : (3.73, 3.29) 배치
             Item basicHouse = itemService.findItemByItemId(BasicItem.HOUSE_01.getItemId());
             Inventory basicHouseInventory = Inventory.builder()
                     .user(userEntity)
@@ -152,7 +152,7 @@ public class UserService {
             basicHouseInventory.getItemPlacement().add(
                     Position.builder()
                             .posX(3.73f)
-                            .posY(5.2f)
+                            .posY(3.29f)
                             .build());
             inventoryService.saveInventory(basicHouseInventory);
 
@@ -167,7 +167,7 @@ public class UserService {
             basicPortalInventory.getItemPlacement().add(
                     Position.builder()
                             .posX(-3.82f)
-                            .posY(4.8f)
+                            .posY(3.8f)
                             .build());
             inventoryService.saveInventory(basicPortalInventory);
 


### PR DESCRIPTION
### 공지사항 생성 API 구현
* 새로운 공지사항을 생성하는 API이다.
* Users 테이블의 role 필드가 "ROLE_ADMIN"인 사용자만 이용할 수 있는 API이다. => 관리자만 이용

### 공지사항 조회 API 구현
* 모든 공지사항을 조회하는 API이다.

###  보유한 행성 아이템 목록 조회 API 수정
* 다음과 같이 response 값 수정
* totalCount - 보유 가능한 개수 (아이템 시트에 설정된 최대 보유 개수)
* placedCount - 배치된 개수
* remainCount - 현재 보유중인 아이템 전체 개수
* totalInventoryItemCount - 전체 인벤에 있는 아이템 개수 (기본 아이템 개수 제외)