### PR TITLE
보유한 행성 아이템 목록 조회 API 에러 수정

### DIFF
--- a/src/main/java/com/planz/planit/src/domain/inventory/InventoryRepository.java
+++ b/src/main/java/com/planz/planit/src/domain/inventory/InventoryRepository.java
@@ -15,7 +15,7 @@ public interface InventoryRepository extends JpaRepository<Inventory, Long> {
     @Query("select i from Inventory i where i.user.userId = :userId and i.planetItem.category = :category")
     List<Inventory> findInventoryItemsByCategory(@Param("userId") Long userId, @Param("category") ItemCategory category);
 
-    @Query("select sum(i.count) from Inventory i where i.user.userId = :userId and i.planetItem.category <> :category ")
+    @Query("select coalesce(sum(i.count), 0) from Inventory i where i.user.userId = :userId and i.planetItem.category <> :category ")
     Integer countTotalInventoriesExcludeCategory(@Param("userId") Long userId, @Param("category") ItemCategory category);
 
     Optional<Inventory> findByUserAndPlanetItem(User user, Item planetItem);


### PR DESCRIPTION
### 보유한 행성 아이템 목록 조회 API 에러 수정
- jpql에서 조회된 데이터가 없는 경우, sum()의 결과는 null이다.
- 이로 인해 null point exception이 발생했다.
- 해결 방안으로 coalesce(sum(i.count), 0)을 이용해서 null 인 경우에 0을 리턴하도록 했다.