### PR TITLE
친구, 목표 조회DTO 수정

### DIFF
--- a/src/main/java/com/planz/planit/src/apicontroller/FriendController.java
+++ b/src/main/java/com/planz/planit/src/apicontroller/FriendController.java
@@ -5,6 +5,7 @@ import com.planz.planit.config.BaseException;
 import com.planz.planit.config.BaseResponse;
 import com.planz.planit.src.domain.friend.Friend;
 import com.planz.planit.src.domain.friend.dto.AcceptReqDTO;
+import com.planz.planit.src.domain.friend.dto.GetFriendListResDTO;
 import com.planz.planit.src.domain.friend.dto.GetFriendResDTO;
 import com.planz.planit.src.service.FriendService;
 import io.swagger.annotations.ApiOperation;
@@ -61,10 +62,10 @@ public class FriendController {
      */
     @GetMapping("/friends")
     @ApiOperation("친구 목록 조회 api")
-    public BaseResponse<List<GetFriendResDTO>> getFriends(HttpServletRequest request) throws BaseException{
+    public BaseResponse<GetFriendListResDTO> getFriends(HttpServletRequest request) throws BaseException{
         Long userId = Long.valueOf(request.getHeader(USER_ID_HEADER_NAME)).longValue();
         try {
-            List<GetFriendResDTO> friends = friendService.getFriends(userId);
+            GetFriendListResDTO friends = friendService.getFriends(userId);
             return new BaseResponse<>(friends);
         }catch(BaseException e){
             return new BaseResponse<>(e.getStatus());

--- a/src/main/java/com/planz/planit/src/apicontroller/GoalController.java
+++ b/src/main/java/com/planz/planit/src/apicontroller/GoalController.java
@@ -6,7 +6,9 @@ import com.planz.planit.config.BaseResponse;
 import com.planz.planit.config.BaseResponseStatus;
 import com.planz.planit.src.domain.goal.dto.CreateGoalReqDTO;
 import com.planz.planit.src.domain.goal.dto.GetGoalDetailResDTO;
+import com.planz.planit.src.domain.goal.dto.GetGoalMainInfoResDTO;
 import com.planz.planit.src.domain.goal.dto.ModifyGoalReqDTO;
+import com.planz.planit.src.domain.user.User;
 import com.planz.planit.src.domain.user.dto.GoalSearchUserResDTO;
 import com.planz.planit.src.service.GoalService;
 import io.swagger.annotations.ApiOperation;
@@ -16,6 +18,10 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
+
+import java.util.List;
+
+import static com.planz.planit.config.BaseResponseStatus.NOT_FRIEND_RELATION;
 
 
 @RestController
@@ -113,6 +119,20 @@ public class GoalController {
             return new BaseResponse<>(resDTO);
 
         }catch(BaseException e){
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
+
+    @GetMapping("/goals/main/{targetUserId}")
+    @ApiOperation("메인화면 조회 API - 투두")
+    public BaseResponse<List<GetGoalMainInfoResDTO>> getGoalMainInfo(HttpServletRequest request, @PathVariable("targetUserId") Long targetUserId){
+        Long userId = Long.valueOf(request.getHeader(USER_ID_HEADER_NAME)).longValue();
+        try{
+            if(userId!=targetUserId){
+                return new BaseResponse<>(goalService.getFriendGoalMainInfo(userId,targetUserId));
+            }
+            return new BaseResponse<>(goalService.getGoalMainInfo(targetUserId)); //나 자신일 때
+        }catch (BaseException e){
             return new BaseResponse<>(e.getStatus());
         }
     }

--- a/src/main/java/com/planz/planit/src/domain/friend/dto/GetFriendListResDTO.java
+++ b/src/main/java/com/planz/planit/src/domain/friend/dto/GetFriendListResDTO.java
@@ -1,0 +1,15 @@
+package com.planz.planit.src.domain.friend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class GetFriendListResDTO {
+    private List<GetFriendResDTO> waitFriends;
+    private List<GetFriendResDTO> friends;
+}

--- a/src/main/java/com/planz/planit/src/domain/friend/dto/GetFriendResDTO.java
+++ b/src/main/java/com/planz/planit/src/domain/friend/dto/GetFriendResDTO.java
@@ -11,5 +11,5 @@ public class GetFriendResDTO {
     private Long userId;
     private String nickName;
     private String profileColor;
-    private String friendStatus;
+    private boolean waitFlag;
 }

--- a/src/main/java/com/planz/planit/src/domain/goal/GoalMember.java
+++ b/src/main/java/com/planz/planit/src/domain/goal/GoalMember.java
@@ -41,7 +41,6 @@ public class GoalMember {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private GroupStatus status; //매니저의 경우 무조건 accept, 다른 멤버는 wait 상태
-
     @Enumerated(EnumType.STRING)
     @Column(name="member_role", nullable=false)
     private GoalMemberRole memberRole;

--- a/src/main/java/com/planz/planit/src/domain/goal/GoalMemberRepository.java
+++ b/src/main/java/com/planz/planit/src/domain/goal/GoalMemberRepository.java
@@ -34,4 +34,7 @@ public interface GoalMemberRepository extends JpaRepository<GoalMember,Long> {
 
     @Query("select count(gm.goalMemberId) from GoalMember gm where gm.goal.goalId is :goalId and gm.member.userId is :userId")
     int checkGoalMember(@Param("goalId") Long goalId, @Param("userId") Long userId);
+
+    @Query("select gm from GoalMember gm where gm.member.userId is :userId")
+    List<GoalMember> findGoalMembersByMember(@Param("userId") Long userId);
 }

--- a/src/main/java/com/planz/planit/src/domain/goal/dto/GetGoalMainInfoResDTO.java
+++ b/src/main/java/com/planz/planit/src/domain/goal/dto/GetGoalMainInfoResDTO.java
@@ -1,21 +1,20 @@
 package com.planz.planit.src.domain.goal.dto;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.util.ArrayList;
 import java.util.List;
 
-@NoArgsConstructor
+@Getter @Setter
 @AllArgsConstructor
-@Getter
-@Setter
-public class GetGoalDetailResDTO {
+public class GetGoalMainInfoResDTO {
     private Long goalId;
     private String goalTitle;
-    private int goalPercentage;
-    private boolean openFlag;
-    private List<GetGoalMemberDetailDTO> goalMemberDetails = new ArrayList<>();
+    private boolean groupFlag;
+    private int percentage;
+    private boolean managerFlag;
+    private List<GetTodoMainResDTO> getTodoMainResList;
 }

--- a/src/main/java/com/planz/planit/src/domain/goal/dto/GetGoalMemberDetailDTO.java
+++ b/src/main/java/com/planz/planit/src/domain/goal/dto/GetGoalMemberDetailDTO.java
@@ -17,5 +17,6 @@ public class GetGoalMemberDetailDTO {
     private Long goalMemberId;
     private String nickname;
     private int percentage;
+    private boolean managerFlag;
     private List<GetTodoMemberDTO> getTodoMembers = new ArrayList<>();
 }

--- a/src/main/java/com/planz/planit/src/domain/goal/dto/GetTodoMainResDTO.java
+++ b/src/main/java/com/planz/planit/src/domain/goal/dto/GetTodoMainResDTO.java
@@ -1,0 +1,17 @@
+package com.planz.planit.src.domain.goal.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class GetTodoMainResDTO {
+    private Long todoMemberId;
+    private String todoTitle;
+    private boolean completeFlag;
+    private int likeCount;
+    private boolean likeFlag;//내가 눌렀는지
+}

--- a/src/main/java/com/planz/planit/src/domain/todo/dto/CheckTodoResDTO.java
+++ b/src/main/java/com/planz/planit/src/domain/todo/dto/CheckTodoResDTO.java
@@ -9,6 +9,5 @@ import lombok.Setter;
 @Setter
 @AllArgsConstructor
 public class CheckTodoResDTO {
-    private boolean levelUpFlag;
-    //레벨 정보?
+    private int percentage;
 }

--- a/src/main/java/com/planz/planit/src/domain/todo/dto/GetTodoMemberDTO.java
+++ b/src/main/java/com/planz/planit/src/domain/todo/dto/GetTodoMemberDTO.java
@@ -15,8 +15,7 @@ import java.util.List;
 public class GetTodoMemberDTO {
     private Long todoMemberId;
     private String todoTitle;
-    private String completeFlag;
+    private boolean completeFlag;
     private int likeCount;
-    private List<LikeUserResDTO> likeUsers= new ArrayList<>();
     private boolean likeFlag;//내가 좋아요를 눌렀는지 확인
 }

--- a/src/main/java/com/planz/planit/src/service/ItemService.java
+++ b/src/main/java/com/planz/planit/src/service/ItemService.java
@@ -177,6 +177,7 @@ public class ItemService {
      */
     public Item findItemByItemId(Long itemId) throws BaseException {
         try {
+            log.info("여기인가");
             return itemRepository.findById(itemId).orElseThrow(() -> new BaseException(INVALID_ITEM_ID));
         }
         catch (BaseException e){


### PR DESCRIPTION
### 친구 조회 API
- 요청 대기 리스트와 수락 리스트를 따로 전달
- flag 를 boolean 값으로 수정

### 메인화면 목표 조회 API
- flag값 boolean으로 통일

### 상세 목표 화면 API
- flag값 boolean으로 통일
- 목표 생성자 여부 추가
- 목표 공개 여부 추가