### PR TITLE
알림 API 구현

### DIFF
--- a/src/main/java/com/planz/planit/config/BaseResponseStatus.java
+++ b/src/main/java/com/planz/planit/config/BaseResponseStatus.java
@@ -162,8 +162,14 @@ public enum BaseResponseStatus {
 
     // 공지사항 관련 BaseResponseStatus
     NOT_EXIST_NOTICE_TITLE(false, 6300, "공지사항 title 을 입력해주세요."),
-    NOT_EXIST_NOTICE_CONTENT(false, 6301, "공지사항 content 를 입력해주세요.")
+    NOT_EXIST_NOTICE_CONTENT(false, 6301, "공지사항 content 를 입력해주세요."),
+
+    // 알림 관련 BaseResponseStatus
+    INVALID_USER_ID_NOTIFICATION_ID(false, 6400, "유효하지 않은 notificationId, userId 조합입니다. 해당 사용자는 해당 알림을 받지 않았습니다."),
+    INVALID_USER_ID_GOAL_ID(false, 6401, "유효하지 않은 userId, goalId 조합입니다. 해당 사용자는 해당 목표를 가지고 있지 않습니다.")
     ;
+
+
 
     private final boolean isSuccess;
     private final int code;

--- a/src/main/java/com/planz/planit/config/BaseResponseStatus.java
+++ b/src/main/java/com/planz/planit/config/BaseResponseStatus.java
@@ -166,7 +166,8 @@ public enum BaseResponseStatus {
 
     // 알림 관련 BaseResponseStatus
     INVALID_USER_ID_NOTIFICATION_ID(false, 6400, "유효하지 않은 notificationId, userId 조합입니다. 해당 사용자는 해당 알림을 받지 않았습니다."),
-    INVALID_USER_ID_GOAL_ID(false, 6401, "유효하지 않은 userId, goalId 조합입니다. 해당 사용자는 해당 목표를 가지고 있지 않습니다.")
+    INVALID_USER_ID_GOAL_ID(false, 6401, "유효하지 않은 userId, goalId 조합입니다. 해당 사용자는 해당 목표를 가지고 있지 않습니다."),
+    INVALID_USER_ID_FRIEND_ID(false, 6402, "유효하지 않은 userId, friendId 조합입니다. 해당 사용자는 해당 친구 요청을 받지 않았습니다.")
     ;
 
 

--- a/src/main/java/com/planz/planit/src/apicontroller/NotificationController.java
+++ b/src/main/java/com/planz/planit/src/apicontroller/NotificationController.java
@@ -2,19 +2,17 @@ package com.planz.planit.src.apicontroller;
 
 import com.planz.planit.config.BaseException;
 import com.planz.planit.config.BaseResponse;
+import com.planz.planit.src.domain.notification.dto.GetNotificationsResDTO;
 import com.planz.planit.src.service.NotificationService;
 import io.swagger.annotations.ApiOperation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
 
 @RestController
-@RequestMapping("/api/notification")
+@RequestMapping("/api/notifications")
 public class NotificationController {
 
     @Value("${jwt.user-id-header-name}")
@@ -26,6 +24,29 @@ public class NotificationController {
     public NotificationController(NotificationService notificationService) {
         this.notificationService = notificationService;
     }
+
+    /**
+     * 모든 알림을 조회한다.
+     * - 공지사항 2개 최상단
+     * - 확정하지 않은 친구 요청, 그룹 초대 요청은 최상단
+     * - 나머지 알림은 시간순으로 최대 200개까지 조회 가능
+     * @RequestHeader User-Id, Jwt-Access-Token
+     * @return
+     */
+    @GetMapping("")
+    @ApiOperation(value = "알림 조회 API")
+    public BaseResponse<GetNotificationsResDTO> getNotifications(HttpServletRequest request){
+
+        Long userId = Long.valueOf(request.getHeader(USER_ID_HEADER_NAME));
+
+        try{
+            return new BaseResponse(notificationService.getNotifications(userId));
+        }
+        catch (BaseException e){
+            return new BaseResponse(e.getStatus());
+        }
+    }
+
 
     /**
      * 알림의 readStatus를 읽음 상태 (READ)로 변경한다.

--- a/src/main/java/com/planz/planit/src/apicontroller/NotificationController.java
+++ b/src/main/java/com/planz/planit/src/apicontroller/NotificationController.java
@@ -1,0 +1,51 @@
+package com.planz.planit.src.apicontroller;
+
+import com.planz.planit.config.BaseException;
+import com.planz.planit.config.BaseResponse;
+import com.planz.planit.src.service.NotificationService;
+import io.swagger.annotations.ApiOperation;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+
+@RestController
+@RequestMapping("/api/notification")
+public class NotificationController {
+
+    @Value("${jwt.user-id-header-name}")
+    private String USER_ID_HEADER_NAME;
+
+    private final NotificationService notificationService;
+
+    @Autowired
+    public NotificationController(NotificationService notificationService) {
+        this.notificationService = notificationService;
+    }
+
+    /**
+     * 알림의 readStatus를 읽음 상태 (READ)로 변경한다.
+     * @RequestHeader User-Id, Jwt-Access-Token
+     * @PathVariable notificationId
+     * @return 결과 메세지
+     */
+    @PatchMapping("/read/{notificationId}")
+    @ApiOperation(value = "알림 읽음 처리 API")
+    public BaseResponse<String> readNotification(HttpServletRequest request,
+                                                 @PathVariable Long notificationId){
+
+        Long userId = Long.valueOf(request.getHeader(USER_ID_HEADER_NAME));
+
+        try {
+            notificationService.readNotification(notificationId, userId);
+            return new BaseResponse<>("성공적으로 해당 알림에 대한 읽음 처리를 진행했습니다.");
+        }
+        catch (BaseException e){
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
+}

--- a/src/main/java/com/planz/planit/src/domain/notification/FriendReqNotification.java
+++ b/src/main/java/com/planz/planit/src/domain/notification/FriendReqNotification.java
@@ -1,0 +1,36 @@
+package com.planz.planit.src.domain.notification;
+
+import com.planz.planit.src.domain.friend.Friend;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import javax.persistence.*;
+
+@Entity
+
+@SuperBuilder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class FriendReqNotification extends Notification { // 친구 초대 알림인 경우
+
+    // 친구
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "friend_id")
+    private Friend friend;
+
+    // 친구 초대 요청에 대한 수락 or 거절 확정 여부
+    @Builder.Default
+    @Enumerated(value = EnumType.STRING)
+    @Column(name = "confirm_status")
+    private NotificationStatus confirmStatus = NotificationStatus.NOT_CONFIRM;
+
+    public void setConfirmStatus(NotificationStatus confirmStatus) {
+        this.confirmStatus = confirmStatus;
+    }
+
+
+}

--- a/src/main/java/com/planz/planit/src/domain/notification/GroupReqNotification.java
+++ b/src/main/java/com/planz/planit/src/domain/notification/GroupReqNotification.java
@@ -1,0 +1,34 @@
+package com.planz.planit.src.domain.notification;
+
+import com.planz.planit.src.domain.goal.Goal;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import javax.persistence.*;
+
+@Entity
+
+@Getter
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GroupReqNotification extends Notification{ // 그룹 목표 초대 알림인 경우
+
+    // 목표
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "goal_id")
+    private Goal goal;
+
+    // 그룹 초대 요청에 대한 수락 or 거절 확정 여부
+    @Builder.Default
+    @Enumerated(value = EnumType.STRING)
+    @Column(name = "confirm_status")
+    private NotificationStatus confirmStatus = NotificationStatus.NOT_CONFIRM;
+
+    public void setConfirmStatus(NotificationStatus confirmStatus) {
+        this.confirmStatus = confirmStatus;
+    }
+}

--- a/src/main/java/com/planz/planit/src/domain/notification/Notification.java
+++ b/src/main/java/com/planz/planit/src/domain/notification/Notification.java
@@ -1,0 +1,55 @@
+package com.planz.planit.src.domain.notification;
+
+import com.planz.planit.src.domain.user.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "DTYPE")
+
+@SuperBuilder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Notification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notification_id")
+    private Long notificationId;
+
+    // 유저
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    // 알림 종류
+    @Enumerated(value = EnumType.STRING)
+    private NotificationSmallCategory category;
+
+    // 알림 내용
+    private String content;
+
+    // 알림 생성일
+    @Builder.Default
+    @Column(name = "create_at")
+    private LocalDateTime createAt = LocalDateTime.now();
+
+    // 읽음 여부
+    @Builder.Default
+    @Enumerated(value = EnumType.STRING)
+    @Column(name = "read_status")
+    private NotificationStatus readStatus = NotificationStatus.NOT_READ;
+
+    public void setReadStatus(NotificationStatus readStatus) {
+        this.readStatus = readStatus;
+    }
+
+}

--- a/src/main/java/com/planz/planit/src/domain/notification/NotificationLargeCategory.java
+++ b/src/main/java/com/planz/planit/src/domain/notification/NotificationLargeCategory.java
@@ -1,0 +1,8 @@
+package com.planz.planit.src.domain.notification;
+
+public enum NotificationLargeCategory {
+    NOTICE,
+    FRIEND,
+    PRIVATE,
+    GROUP
+}

--- a/src/main/java/com/planz/planit/src/domain/notification/NotificationRepository.java
+++ b/src/main/java/com/planz/planit/src/domain/notification/NotificationRepository.java
@@ -1,0 +1,16 @@
+package com.planz.planit.src.domain.notification;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface NotificationRepository<T extends Notification> extends JpaRepository<T, Long> {
+
+    @Query(value = "select n from Notification n where n.notificationId = :notificationId and n.user.userId = :userId")
+    Optional<Notification> findByNotificationIdAndUserId(@Param("notificationId") Long notificationId, @Param("userId") Long userId);
+
+    @Query(value = "select grn from GroupReqNotification grn where grn.user.userId = :userId and grn.goal.goalId = :goalId")
+    Optional<GroupReqNotification> findByUserIdAndGoalId(@Param("userId") Long userId, @Param("goalId") Long goalId);
+}

--- a/src/main/java/com/planz/planit/src/domain/notification/NotificationRepository.java
+++ b/src/main/java/com/planz/planit/src/domain/notification/NotificationRepository.java
@@ -4,6 +4,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface NotificationRepository<T extends Notification> extends JpaRepository<T, Long> {
@@ -13,4 +14,16 @@ public interface NotificationRepository<T extends Notification> extends JpaRepos
 
     @Query(value = "select grn from GroupReqNotification grn where grn.user.userId = :userId and grn.goal.goalId = :goalId")
     Optional<GroupReqNotification> findByUserIdAndGoalId(@Param("userId") Long userId, @Param("goalId") Long goalId);
+
+    @Query(value = "select frn from FriendReqNotification frn where frn.user.userId = :userId and frn.friend.friendId = :friendId")
+    Optional<FriendReqNotification> findByUserIdAndFriendId(@Param("userId") Long userId, @Param("friendId") Long friendId);
+
+    @Query(value = "select grn from GroupReqNotification grn where grn.user.userId = :userId and grn.confirmStatus = :confirmStatus")
+    List<GroupReqNotification> getAllNotConfirmedGroupReqNotis(@Param("userId") Long userId, @Param("confirmStatus") NotificationStatus confirmStatus);
+
+    @Query(value = "select frn from FriendReqNotification frn where frn.user.userId = :userId and frn.confirmStatus = :confirmStatus")
+    List<FriendReqNotification> getAllNotConfirmedFriendReqNotis(@Param("userId") Long userId, @Param("confirmStatus") NotificationStatus confirmStatus);
+
+    @Query(value = "select n from Notification n where n.user.userId = :userId")
+    List<Notification> getAllNotifications(@Param("userId") Long userId);
 }

--- a/src/main/java/com/planz/planit/src/domain/notification/NotificationSmallCategory.java
+++ b/src/main/java/com/planz/planit/src/domain/notification/NotificationSmallCategory.java
@@ -1,0 +1,32 @@
+package com.planz.planit.src.domain.notification;
+
+import lombok.Getter;
+
+import static com.planz.planit.src.domain.notification.NotificationLargeCategory.*;
+
+@Getter
+public enum NotificationSmallCategory {
+
+    NOTICE_TWO(NOTICE, "공지사항 알림"),
+
+    FRIEND_REQUEST(FRIEND,"친구 요청"),
+    FRIEND_ACCEPT(FRIEND,"친구 수락"),
+
+    PRIVATE_FAVORITE(PRIVATE, "개인 투두 좋아요"),
+    PRIVATE_CHEER(PRIVATE, "개인 투두 응원"),
+
+    GROUP_REQUEST(GROUP, "그룹 초대 요청"),
+    GROUP_ACCEPT(GROUP, "그룹 초대 수락"),
+    GROUP_DONE(GROUP, "그룹 투두 완료"),
+    GROUP_FAVORITE(GROUP, "그룹 투두 좋아요"),
+    GROUP_CHEER(GROUP, "그룹 투두 응원");
+
+
+    private final NotificationLargeCategory largeCategory;
+    private final String kName;
+
+    NotificationSmallCategory(NotificationLargeCategory largeCategory, String kName) {
+        this.largeCategory = largeCategory;
+        this.kName = kName;
+    }
+}

--- a/src/main/java/com/planz/planit/src/domain/notification/NotificationStatus.java
+++ b/src/main/java/com/planz/planit/src/domain/notification/NotificationStatus.java
@@ -1,0 +1,6 @@
+package com.planz.planit.src.domain.notification;
+
+public enum NotificationStatus {
+
+    READ, NOT_READ, CONFIRM, NOT_CONFIRM
+}

--- a/src/main/java/com/planz/planit/src/domain/notification/dto/GetNotificationsResDTO.java
+++ b/src/main/java/com/planz/planit/src/domain/notification/dto/GetNotificationsResDTO.java
@@ -1,0 +1,80 @@
+package com.planz.planit.src.domain.notification.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import com.planz.planit.src.domain.notification.NotificationStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class GetNotificationsResDTO {
+
+    // "공지사항" 알림 리스트
+    List<BasicNotificationDTO> noticeNotifications;
+
+    // "친구 요청" 알림 리스트
+    List<FriendReqNotificationDTO> friendReqNotifications;
+
+    // "그룹 초대 요청" 알림 리스트
+    List<GroupReqNotificationDTO> groupReqNotifications;
+
+    // "그 외" 알림 리스트
+    List<BasicNotificationDTO> etcNotifications;
+
+
+    @Getter
+    @Builder
+    public static class BasicNotificationDTO{
+        private Long notificationId;
+        private Long userId;
+        private String category;
+        private String content;
+
+        @JsonSerialize(using = LocalDateTimeSerializer.class)
+        @JsonFormat(pattern = "yyyy-MM-dd kk:mm:ss")
+        private LocalDateTime createAt;
+
+        private String readStatus;
+    }
+
+    @Getter
+    @Builder
+    public static class FriendReqNotificationDTO{
+        private Long notificationId;
+        private Long userId;
+        private String category;
+        private String content;
+
+        // 자바 클래스 -> json 으로 serialize할 때 문제가 생기므로 추가
+        @JsonSerialize(using = LocalDateTimeSerializer.class)
+        @JsonFormat(pattern = "yyyy-MM-dd kk:mm:ss")
+        private LocalDateTime createAt;
+
+        private String readStatus;
+        private Long friendId;
+        private String confirmStatus;
+    }
+
+    @Getter
+    @Builder
+    public static class GroupReqNotificationDTO{
+        private Long notificationId;
+        private Long userId;
+        private String category;
+        private String content;
+
+        // 자바 클래스 -> json 으로 serialize할 때 문제가 생기므로 추가
+        @JsonSerialize(using = LocalDateTimeSerializer.class)
+        @JsonFormat(pattern = "yyyy-MM-dd kk:mm:ss")
+        private LocalDateTime createAt;
+
+        private String readStatus;
+        private Long goalId;
+        private String confirmStatus;
+    }
+}

--- a/src/main/java/com/planz/planit/src/domain/user/UserRepository.java
+++ b/src/main/java/com/planz/planit/src/domain/user/UserRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -24,4 +25,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Query("delete from User u where u.userId is :userId")
     void deleteByUserIdInQuery(@Param("userId") Long userId);
 
+    @Override
+    List<User> findAll();
 }

--- a/src/main/java/com/planz/planit/src/service/NoticeService.java
+++ b/src/main/java/com/planz/planit/src/service/NoticeService.java
@@ -5,6 +5,8 @@ import com.planz.planit.config.BaseResponseStatus;
 import com.planz.planit.src.domain.notice.Notice;
 import com.planz.planit.src.domain.notice.NoticeRepository;
 import com.planz.planit.src.domain.notice.dto.GetNoticesResDTO;
+import com.planz.planit.src.domain.notification.NotificationSmallCategory;
+import com.planz.planit.src.domain.user.User;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Sort;
@@ -20,10 +22,14 @@ import static com.planz.planit.config.BaseResponseStatus.DATABASE_ERROR;
 public class NoticeService {
 
     private final NoticeRepository noticeRepository;
+    private final NotificationService notificationService;
+    private final UserService userService;
 
     @Autowired
-    public NoticeService(NoticeRepository noticeRepository) {
+    public NoticeService(NoticeRepository noticeRepository, NotificationService notificationService, UserService userService) {
         this.noticeRepository = noticeRepository;
+        this.notificationService = notificationService;
+        this.userService = userService;
     }
 
 
@@ -31,6 +37,7 @@ public class NoticeService {
      * 공지사항 생성 API (ROLE_ADMIN 권한을 가진 사용자만 이용 가능)
      * 1. Notice 엔티티 생성
      * 2. Notice 엔티티 저장
+     * 3. 공지사항 알림 생성
      */
     public void createNotice(String title, String content) throws BaseException {
 
@@ -43,6 +50,12 @@ public class NoticeService {
 
             // 2. Notice 엔티티 저장
             saveNotice(notice);
+
+            // 3. 공지사항 알림 생성
+            List<User> allUser = userService.findAllUser();
+            for (User user : allUser) {
+                notificationService.createNotification(user, NotificationSmallCategory.NOTICE_TWO, "[공지] " + notice.getTitle(), null);
+            }
         } catch (BaseException e) {
             throw e;
         }

--- a/src/main/java/com/planz/planit/src/service/NoticeService.java
+++ b/src/main/java/com/planz/planit/src/service/NoticeService.java
@@ -54,7 +54,7 @@ public class NoticeService {
             // 3. 공지사항 알림 생성
             List<User> allUser = userService.findAllUser();
             for (User user : allUser) {
-                notificationService.createNotification(user, NotificationSmallCategory.NOTICE_TWO, "[공지] " + notice.getTitle(), null);
+                notificationService.createNotification(user, NotificationSmallCategory.NOTICE_TWO, "[공지] " + notice.getTitle(), null, null);
             }
         } catch (BaseException e) {
             throw e;

--- a/src/main/java/com/planz/planit/src/service/NotificationService.java
+++ b/src/main/java/com/planz/planit/src/service/NotificationService.java
@@ -1,6 +1,7 @@
 package com.planz.planit.src.service;
 
 import com.planz.planit.config.BaseException;
+import com.planz.planit.src.domain.friend.Friend;
 import com.planz.planit.src.domain.goal.Goal;
 import com.planz.planit.src.domain.notification.*;
 import com.planz.planit.src.domain.notification.dto.GetNotificationsResDTO;
@@ -31,15 +32,29 @@ public class NotificationService {
     /**
      * 알림 생성 함수
      */
-    public void createNotification(User user, NotificationSmallCategory category, String content, Goal goal) throws BaseException {
+    public void createNotification(User user, NotificationSmallCategory category, String content, Friend friend, Goal goal) throws BaseException {
         try {
 
             if (user == null || category == null || content == null) {
                 throw new NullPointerException("user, category, content를 모두 입력해주세요.");
             }
 
+            // 친구 요청 알림인 경우
+            if (category == FRIEND_REQUEST){
+                if (friend == null) {
+                    throw new NullPointerException("friend를 입력해주세요.");
+                }
+
+                FriendReqNotification notification = FriendReqNotification.builder()
+                        .user(user)
+                        .category(category)
+                        .content(content)
+                        .friend(friend)
+                        .build();
+                saveNotification(notification);
+            }
             // 그룹 초대 요청 알림인 경우
-            if (category == NotificationSmallCategory.GROUP_REQUEST) {
+            else if (category == GROUP_REQUEST) {
                 if (goal == null) {
                     throw new NullPointerException("goal을 입력해주세요.");
                 }

--- a/src/main/java/com/planz/planit/src/service/NotificationService.java
+++ b/src/main/java/com/planz/planit/src/service/NotificationService.java
@@ -1,0 +1,169 @@
+package com.planz.planit.src.service;
+
+import com.planz.planit.config.BaseException;
+import com.planz.planit.src.domain.goal.Goal;
+import com.planz.planit.src.domain.notification.*;
+import com.planz.planit.src.domain.user.User;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import static com.planz.planit.config.BaseResponseStatus.*;
+import static com.planz.planit.src.domain.notification.NotificationLargeCategory.*;
+
+@Service
+@Log4j2
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+
+    @Autowired
+    public NotificationService(NotificationRepository notificationRepository) {
+        this.notificationRepository = notificationRepository;
+    }
+
+    /**
+     * 알림 생성 함수
+     */
+    public void createNotification(User user, NotificationSmallCategory category, String content, Goal goal) throws BaseException{
+        try{
+
+            if(user == null || category == null || content == null){
+                throw new NullPointerException("user, category, content를 모두 입력해주세요.");
+            }
+
+            // 그룹 초대 요청 알림인 경우
+            if(category == NotificationSmallCategory.GROUP_REQUEST){
+                if (goal == null){
+                    throw new NullPointerException("goal을 입력해주세요.");
+                }
+
+                GroupReqNotification notification = GroupReqNotification.builder()
+                        .user(user)
+                        .category(category)
+                        .content(content)
+                        .goal(goal)
+                        .build();
+                saveNotification(notification);
+            }
+            // 그 외 알림인 경우
+            else{
+                Notification notification = Notification.builder()
+                        .user(user)
+                        .category(category)
+                        .content(content)
+                        .build();
+
+                saveNotification(notification);
+            }
+
+
+            // 푸쉬 알림 보내기
+            if(category.getLargeCategory() == NOTICE){
+
+            }
+            else if(category.getLargeCategory() == FRIEND){
+
+            }
+            else if(category.getLargeCategory() == PRIVATE){
+
+            }
+            else {
+
+            }
+
+        }
+        catch (BaseException e){
+            throw e;
+        }
+    }
+
+
+    /**
+     * Notification 엔티티 저장 혹은 업데이트
+     */
+    public void saveNotification(Notification notificationEntity) throws BaseException {
+        try{
+            notificationRepository.save(notificationEntity);
+        }
+        catch (Exception e){
+            log.error("saveNotification() : notificationRepository.save(notificationEntity) 실행 중 데이터베이스 에러 발생");
+            e.printStackTrace();
+            throw new BaseException(DATABASE_ERROR);
+        }
+    }
+
+    /**
+     * 알림 읽음 처리 API
+     * 1. notificationId와 userId로 Notification 엔티티 조회
+     * 2. 조회한 Notification의 readStatus를 읽음 상태(READ)로 변경
+     */
+    public void readNotification(Long notificationId, Long userId) throws BaseException{
+
+        try{
+            // 1. notificationId와 userId로 Notification 엔티티 조회
+            Notification notification = findByNotificationIdAndUserId(notificationId, userId);
+
+            // 2. 조회한 Notification의 readStatus를 읽음 상태(READ)로 변경
+            notification.setReadStatus(NotificationStatus.READ);
+            saveNotification(notification);
+        }
+        catch (BaseException e){
+            throw e;
+        }
+    }
+
+    /**
+     * 그룹 초대 요청 알림에 대한 확정 처리
+     * 1. userId, goalId로 Notification 엔티티 조회
+     * 2. 조회한 Notification의 confirmStatus를 확정 상태(CONFIRM)로 변경
+     */
+    public void confirmNotification(Long userId, Long goalId) throws BaseException{
+        try{
+            // 1. userId, goalId로 Notification 엔티티 조회
+            GroupReqNotification notification = findByUserIdAndGoalId(userId, goalId);
+
+            // 2. 조회한 Notification의 confirmStatus를 확정 상태(CONFIRM)로 변경
+            notification.setConfirmStatus(NotificationStatus.CONFIRM);
+            saveNotification(notification);
+        }
+        catch (BaseException e){
+            throw e;
+        }
+    }
+
+    /**
+     * notificationId와 userId로 DB에서 Notification 엔티티 조회
+     */
+    public Notification findByNotificationIdAndUserId(Long notificationId, Long userId) throws BaseException{
+        try{
+            return (Notification) notificationRepository.findByNotificationIdAndUserId(notificationId, userId).orElseThrow(()->new BaseException(INVALID_USER_ID_NOTIFICATION_ID));
+        }
+        catch (BaseException e){
+            throw e;
+        }
+        catch (Throwable e){
+            log.error("findByNotificationIdAndUserId(): notificationRepository.findByNotificationIdAndUserId() 실행 중 데이터베이스 에러 발생");
+            e.printStackTrace();
+            throw new BaseException(DATABASE_ERROR);
+        }
+    }
+
+    /**
+     * userId와 goalId로 DB에서 GroupReqNotification 엔티티 조회
+     */
+    public GroupReqNotification findByUserIdAndGoalId(Long userId, Long goalId) throws BaseException{
+        try{
+            return (GroupReqNotification) notificationRepository.findByUserIdAndGoalId(userId, goalId).orElseThrow(()->new BaseException(INVALID_USER_ID_GOAL_ID));
+        }
+        catch (BaseException e){
+            throw e;
+        }
+        catch (Throwable e){
+            log.error("findByUserIdAndGoalId(): notificationRepository.findByNotificationIdAndUserId() 실행 중 데이터베이스 에러 발생");
+            e.printStackTrace();
+            throw new BaseException(DATABASE_ERROR);
+        }
+    }
+
+}

--- a/src/main/java/com/planz/planit/src/service/NotificationService.java
+++ b/src/main/java/com/planz/planit/src/service/NotificationService.java
@@ -3,13 +3,19 @@ package com.planz.planit.src.service;
 import com.planz.planit.config.BaseException;
 import com.planz.planit.src.domain.goal.Goal;
 import com.planz.planit.src.domain.notification.*;
+import com.planz.planit.src.domain.notification.dto.GetNotificationsResDTO;
 import com.planz.planit.src.domain.user.User;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import static com.planz.planit.config.BaseResponseStatus.*;
 import static com.planz.planit.src.domain.notification.NotificationLargeCategory.*;
+import static com.planz.planit.src.domain.notification.NotificationSmallCategory.*;
 
 @Service
 @Log4j2
@@ -25,16 +31,16 @@ public class NotificationService {
     /**
      * 알림 생성 함수
      */
-    public void createNotification(User user, NotificationSmallCategory category, String content, Goal goal) throws BaseException{
-        try{
+    public void createNotification(User user, NotificationSmallCategory category, String content, Goal goal) throws BaseException {
+        try {
 
-            if(user == null || category == null || content == null){
+            if (user == null || category == null || content == null) {
                 throw new NullPointerException("user, category, content를 모두 입력해주세요.");
             }
 
             // 그룹 초대 요청 알림인 경우
-            if(category == NotificationSmallCategory.GROUP_REQUEST){
-                if (goal == null){
+            if (category == NotificationSmallCategory.GROUP_REQUEST) {
+                if (goal == null) {
                     throw new NullPointerException("goal을 입력해주세요.");
                 }
 
@@ -47,7 +53,7 @@ public class NotificationService {
                 saveNotification(notification);
             }
             // 그 외 알림인 경우
-            else{
+            else {
                 Notification notification = Notification.builder()
                         .user(user)
                         .category(category)
@@ -59,21 +65,17 @@ public class NotificationService {
 
 
             // 푸쉬 알림 보내기
-            if(category.getLargeCategory() == NOTICE){
+            if (category.getLargeCategory() == NOTICE) {
 
-            }
-            else if(category.getLargeCategory() == FRIEND){
+            } else if (category.getLargeCategory() == FRIEND) {
 
-            }
-            else if(category.getLargeCategory() == PRIVATE){
+            } else if (category.getLargeCategory() == PRIVATE) {
 
-            }
-            else {
+            } else {
 
             }
 
-        }
-        catch (BaseException e){
+        } catch (BaseException e) {
             throw e;
         }
     }
@@ -83,10 +85,9 @@ public class NotificationService {
      * Notification 엔티티 저장 혹은 업데이트
      */
     public void saveNotification(Notification notificationEntity) throws BaseException {
-        try{
+        try {
             notificationRepository.save(notificationEntity);
-        }
-        catch (Exception e){
+        } catch (Exception e) {
             log.error("saveNotification() : notificationRepository.save(notificationEntity) 실행 중 데이터베이스 에러 발생");
             e.printStackTrace();
             throw new BaseException(DATABASE_ERROR);
@@ -98,17 +99,16 @@ public class NotificationService {
      * 1. notificationId와 userId로 Notification 엔티티 조회
      * 2. 조회한 Notification의 readStatus를 읽음 상태(READ)로 변경
      */
-    public void readNotification(Long notificationId, Long userId) throws BaseException{
+    public void readNotification(Long notificationId, Long userId) throws BaseException {
 
-        try{
+        try {
             // 1. notificationId와 userId로 Notification 엔티티 조회
             Notification notification = findByNotificationIdAndUserId(notificationId, userId);
 
             // 2. 조회한 Notification의 readStatus를 읽음 상태(READ)로 변경
             notification.setReadStatus(NotificationStatus.READ);
             saveNotification(notification);
-        }
-        catch (BaseException e){
+        } catch (BaseException e) {
             throw e;
         }
     }
@@ -118,16 +118,33 @@ public class NotificationService {
      * 1. userId, goalId로 Notification 엔티티 조회
      * 2. 조회한 Notification의 confirmStatus를 확정 상태(CONFIRM)로 변경
      */
-    public void confirmNotification(Long userId, Long goalId) throws BaseException{
-        try{
+    public void confirmGroupReqNotification(Long userId, Long goalId) throws BaseException {
+        try {
             // 1. userId, goalId로 Notification 엔티티 조회
             GroupReqNotification notification = findByUserIdAndGoalId(userId, goalId);
 
             // 2. 조회한 Notification의 confirmStatus를 확정 상태(CONFIRM)로 변경
             notification.setConfirmStatus(NotificationStatus.CONFIRM);
             saveNotification(notification);
+        } catch (BaseException e) {
+            throw e;
         }
-        catch (BaseException e){
+    }
+
+    /**
+     * 친구 요청 알림에 대한 확정 처리
+     * 1. userId, friendId로 Notification 엔티티 조회
+     * 2. 조회한 Notification의 confirmStatus를 확정 상태(CONFIRM)로 변경
+     */
+    public void confirmFriendReqNotification(Long userId, Long friendId) throws BaseException {
+        try {
+            // 1. userId, friendId로 Notification 엔티티 조회
+            FriendReqNotification notification = findByUserIdAndFriendId(userId, friendId);
+
+            // 2. 조회한 Notification의 confirmStatus를 확정 상태(CONFIRM)로 변경
+            notification.setConfirmStatus(NotificationStatus.CONFIRM);
+            saveNotification(notification);
+        } catch (BaseException e) {
             throw e;
         }
     }
@@ -135,14 +152,12 @@ public class NotificationService {
     /**
      * notificationId와 userId로 DB에서 Notification 엔티티 조회
      */
-    public Notification findByNotificationIdAndUserId(Long notificationId, Long userId) throws BaseException{
-        try{
-            return (Notification) notificationRepository.findByNotificationIdAndUserId(notificationId, userId).orElseThrow(()->new BaseException(INVALID_USER_ID_NOTIFICATION_ID));
-        }
-        catch (BaseException e){
+    public Notification findByNotificationIdAndUserId(Long notificationId, Long userId) throws BaseException {
+        try {
+            return (Notification) notificationRepository.findByNotificationIdAndUserId(notificationId, userId).orElseThrow(() -> new BaseException(INVALID_USER_ID_NOTIFICATION_ID));
+        } catch (BaseException e) {
             throw e;
-        }
-        catch (Throwable e){
+        } catch (Throwable e) {
             log.error("findByNotificationIdAndUserId(): notificationRepository.findByNotificationIdAndUserId() 실행 중 데이터베이스 에러 발생");
             e.printStackTrace();
             throw new BaseException(DATABASE_ERROR);
@@ -152,18 +167,155 @@ public class NotificationService {
     /**
      * userId와 goalId로 DB에서 GroupReqNotification 엔티티 조회
      */
-    public GroupReqNotification findByUserIdAndGoalId(Long userId, Long goalId) throws BaseException{
-        try{
-            return (GroupReqNotification) notificationRepository.findByUserIdAndGoalId(userId, goalId).orElseThrow(()->new BaseException(INVALID_USER_ID_GOAL_ID));
-        }
-        catch (BaseException e){
+    public GroupReqNotification findByUserIdAndGoalId(Long userId, Long goalId) throws BaseException {
+        try {
+            return (GroupReqNotification) notificationRepository.findByUserIdAndGoalId(userId, goalId).orElseThrow(() -> new BaseException(INVALID_USER_ID_GOAL_ID));
+        } catch (BaseException e) {
             throw e;
-        }
-        catch (Throwable e){
-            log.error("findByUserIdAndGoalId(): notificationRepository.findByNotificationIdAndUserId() 실행 중 데이터베이스 에러 발생");
+        } catch (Throwable e) {
+            log.error("findByUserIdAndGoalId(): notificationRepository.findByUserIdAndGoalId() 실행 중 데이터베이스 에러 발생");
             e.printStackTrace();
             throw new BaseException(DATABASE_ERROR);
         }
     }
 
+    /**
+     * userId와 friendId로 DB에서 FriendReqNotification 엔티티 조회
+     */
+    public FriendReqNotification findByUserIdAndFriendId(Long userId, Long friendId) throws BaseException {
+        try {
+            return (FriendReqNotification) notificationRepository.findByUserIdAndFriendId(userId, friendId).orElseThrow(() -> new BaseException(INVALID_USER_ID_FRIEND_ID));
+        } catch (BaseException e) {
+            throw e;
+        } catch (Throwable e) {
+            log.error("findByUserIdAndFriendId(): notificationRepository.findByUserIdAndFriendId() 실행 중 데이터베이스 에러 발생");
+            e.printStackTrace();
+            throw new BaseException(DATABASE_ERROR);
+        }
+    }
+
+    /**
+     * 알림 조회 API
+     * - 공지사항 2개 최상단
+     * - 확정하지 않은 친구 요청, 그룹 초대 요청은 최상단
+     * - 나머지 알림은 시간순으로 최대 200개까지 조회 가능
+     * 1.
+     */
+    public GetNotificationsResDTO getNotifications(Long userId) throws BaseException {
+
+        try {
+
+            List<GroupReqNotification> groupReqNotifications = getAllNotConfirmedGroupReqNotis(userId);
+            List<GetNotificationsResDTO.GroupReqNotificationDTO> groupReqNotificationsResult = groupReqNotifications.stream().
+                    map(n -> GetNotificationsResDTO.GroupReqNotificationDTO.builder()
+                            .notificationId(n.getNotificationId())
+                            .userId(n.getUser().getUserId())
+                            .category(n.getCategory().name())
+                            .content(n.getContent())
+                            .createAt(n.getCreateAt())
+                            .readStatus(n.getReadStatus().name())
+                            .goalId(n.getGoal().getGoalId())
+                            .confirmStatus(n.getConfirmStatus().name())
+                            .build())
+                    .sorted(Comparator.comparing(GetNotificationsResDTO.GroupReqNotificationDTO::getCreateAt).reversed())
+                    .collect(Collectors.toList());
+
+
+            List<FriendReqNotification> friendReqNotifications = getAllNotConfirmedFriendReqNotis(userId);
+            List<GetNotificationsResDTO.FriendReqNotificationDTO> friendReqNotificationsResult = friendReqNotifications.stream()
+                    .map(n -> GetNotificationsResDTO.FriendReqNotificationDTO.builder()
+                            .notificationId(n.getNotificationId())
+                            .userId(n.getUser().getUserId())
+                            .category(n.getCategory().name())
+                            .content(n.getContent())
+                            .createAt(n.getCreateAt())
+                            .readStatus(n.getReadStatus().name())
+                            .friendId(n.getFriend().getFriendId())
+                            .confirmStatus(n.getConfirmStatus().name())
+                            .build())
+                    .sorted(Comparator.comparing(GetNotificationsResDTO.FriendReqNotificationDTO::getCreateAt).reversed())
+                    .collect(Collectors.toList());
+
+
+            List<Notification> noticeNotifications = getAllNotifications(userId);
+            List<GetNotificationsResDTO.BasicNotificationDTO> noticeNotificationsResult =
+                    noticeNotifications.stream()
+                            .filter(n -> n.getCategory() == NOTICE_TWO)
+                            .map(n -> GetNotificationsResDTO.BasicNotificationDTO.builder()
+                                    .notificationId(n.getNotificationId())
+                                    .userId(n.getUser().getUserId())
+                                    .category(n.getCategory().name())
+                                    .content(n.getContent())
+                                    .createAt(n.getCreateAt())
+                                    .readStatus(n.getReadStatus().name())
+                                    .build())
+                            .sorted(Comparator.comparing(GetNotificationsResDTO.BasicNotificationDTO::getCreateAt).reversed())
+                            .limit(2)
+                            .collect(Collectors.toList());
+
+            List<GetNotificationsResDTO.BasicNotificationDTO> etcNotificationsResult =
+                    noticeNotifications.stream()
+                            .filter(n -> n.getCategory() != NOTICE_TWO && n.getCategory() != FRIEND_REQUEST && n.getCategory() != GROUP_REQUEST)
+                            .map(n -> GetNotificationsResDTO.BasicNotificationDTO.builder()
+                                    .notificationId(n.getNotificationId())
+                                    .userId(n.getUser().getUserId())
+                                    .category(n.getCategory().name())
+                                    .content(n.getContent())
+                                    .createAt(n.getCreateAt())
+                                    .readStatus(n.getReadStatus().name())
+                                    .build())
+                            .sorted(Comparator.comparing(GetNotificationsResDTO.BasicNotificationDTO::getCreateAt).reversed())
+                            .limit(200 - noticeNotificationsResult.size() - friendReqNotificationsResult.size() - groupReqNotificationsResult.size())
+                            .collect(Collectors.toList());
+
+            return GetNotificationsResDTO.builder()
+                    .noticeNotifications(noticeNotificationsResult)
+                    .friendReqNotifications(friendReqNotificationsResult)
+                    .groupReqNotifications(groupReqNotificationsResult)
+                    .etcNotifications(etcNotificationsResult)
+                    .build();
+
+        } catch (BaseException e) {
+            throw e;
+        }
+    }
+
+    /**
+     * userId로 DB에서 모든 확정되지 않은 GroupReqNotification 엔티티 조회
+     */
+    public List<GroupReqNotification> getAllNotConfirmedGroupReqNotis(Long userId) throws BaseException {
+        try {
+            return notificationRepository.getAllNotConfirmedGroupReqNotis(userId, NotificationStatus.NOT_CONFIRM);
+        } catch (Exception e) {
+            log.error("getAllNotConfirmedGroupReqNotis() : notificationRepository.getAllNotConfirmedGroupReqNotis() 실행 중 데이터베이스 에러 발생");
+            e.printStackTrace();
+            throw new BaseException(DATABASE_ERROR);
+        }
+    }
+
+    /**
+     * userId로 DB에서 모든 확정되지 않은 FriendReqNotification 엔티티 조회
+     */
+    public List<FriendReqNotification> getAllNotConfirmedFriendReqNotis(Long userId) throws BaseException {
+        try {
+            return notificationRepository.getAllNotConfirmedFriendReqNotis(userId, NotificationStatus.NOT_CONFIRM);
+        } catch (Exception e) {
+            log.error("getAllNotConfirmedFriendReqNotis() : notificationRepository.getAllNotConfirmedFriendReqNotis() 실행 중 데이터베이스 에러 발생");
+            e.printStackTrace();
+            throw new BaseException(DATABASE_ERROR);
+        }
+    }
+
+    /**
+     * userId로 DB에서 모든 Notification 엔티티 조회
+     */
+    public List<Notification> getAllNotifications(Long userId) throws BaseException {
+        try {
+            return notificationRepository.getAllNotifications(userId);
+        } catch (Exception e) {
+            log.error("getAllNotifications() : notificationRepository.getAllNotifications(userId) 실행 중 데이터베이스 에러 발생");
+            e.printStackTrace();
+            throw new BaseException(DATABASE_ERROR);
+        }
+    }
 }

--- a/src/main/java/com/planz/planit/src/service/UserService.java
+++ b/src/main/java/com/planz/planit/src/service/UserService.java
@@ -650,4 +650,18 @@ public class UserService {
             throw e;
         }
     }
+
+    /**
+     * 모든 유저 검색
+     */
+    public List<User> findAllUser() throws BaseException {
+        try{
+            return userRepository.findAll();
+        }
+        catch (Exception e){
+            log.error("findAllUser() : userRepository.findAll() 실행 중 데이터베이스 에러 발생");
+            e.printStackTrace();
+            throw new BaseException(DATABASE_ERROR);
+        }
+    }
 }


### PR DESCRIPTION
### 알림 생성 함수 추가
* NotificationService.createNotification(User user, NotificationSmallCategory category, String content, Friend friend, Goal goal) 함수
* **추후에 push 알림을 보내는 로직 추가 필요** 

### 알림 조회 API 구현
* 다음 4가지 리스트를 response로 반환
1) 최대 2개의 공지사항 알림 리스트
2) **확정하지 않은** 친구 요청 리스트
3) **확정하지 않은** 그룹 초대 요청 알림 리스트
4) 나머지 알림 리스트 
* 각 리스트는 최신 순으로 정렬되어 있고, 알림은 총 200개를 넘지 않음
