### PR TITLE
FCM 코드 추가 및 메일 전송 에러 해결

### DIFF
--- a/src/main/java/com/planz/planit/config/batch/BatchConfig.java
+++ b/src/main/java/com/planz/planit/config/batch/BatchConfig.java
@@ -1,5 +1,6 @@
 package com.planz.planit.config.batch;
 
+import com.planz.planit.config.BaseException;
 import com.planz.planit.config.fcm.FirebaseCloudMessageService;
 import com.planz.planit.src.domain.deviceToken.DeviceToken;
 import com.planz.planit.src.service.DeviceTokenService;
@@ -58,16 +59,19 @@ public class BatchConfig {
 
                     // MySQL의 가출 프로시저 (run_away) 실행
                     List<DeviceToken> deviceTokenList = deviceTokenService.callRunAwayProcedure();
+                    // setting_flag가 1이고, 가출 상태인 사용자의 deviceToken 값 리스트
                     List<String> deviceTokens = deviceTokenList.stream()
                             .map(DeviceToken::getDeviceToken)
                             .collect(Collectors.toList());
 
-                    for (String deviceToken : deviceTokens) {
-                        log.info("디바이스 토큰 : " + deviceToken);
+                    try{
+                        // push 알림 전송
+                        firebaseCloudMessageService.sendMessageTo(deviceTokens, "[가출]", "별 주민이 우주선을 타고 행성을 떠났습니다. 빨리 행성을 확인해주세요!");
+                        log.info("[FCM 전송 성공] setting_flag가 1이고 가출 상태인 사용자에게, 가출 FCM 전송 성공");
                     }
-
-                    // push 알림 전송 => flag값 확인 !!
-                    //firebaseCloudMessageService.sendMessageTo(deviceTokens, "[가출]", "별 주민이 우주선을 타고 행성을 떠났습니다. 빨리 행성을 확인해주세요!", 1);
+                    catch (BaseException e){
+                        log.error("[FCM 전송 실패] " + e.getStatus());
+                    }
 
                     return RepeatStatus.FINISHED;
                 })

--- a/src/main/java/com/planz/planit/config/batch/BatchScheduler.java
+++ b/src/main/java/com/planz/planit/config/batch/BatchScheduler.java
@@ -29,7 +29,7 @@ public class BatchScheduler {
     }
 
     //초 분 시 일 월 요일
-    @Scheduled(cron = "0 54 1 * * *")
+    @Scheduled(cron = "0 0 0 * * *")
     public void runJob(){
         Map<String, JobParameter> confMap = new HashMap<>();
         confMap.put("time", new JobParameter(System.currentTimeMillis()));

--- a/src/main/java/com/planz/planit/src/apicontroller/NoticeController.java
+++ b/src/main/java/com/planz/planit/src/apicontroller/NoticeController.java
@@ -6,24 +6,30 @@ import com.planz.planit.config.BaseResponseStatus;
 import com.planz.planit.config.fcm.FirebaseCloudMessageService;
 import com.planz.planit.src.domain.notice.dto.CreateNoticeReqDTO;
 import com.planz.planit.src.domain.notice.dto.GetNoticesResDTO;
+import com.planz.planit.src.service.DeviceTokenService;
 import com.planz.planit.src.service.NoticeService;
 import io.swagger.annotations.ApiOperation;
+import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.util.List;
 
+@Log4j2
 @RestController
 public class NoticeController {
 
     private final NoticeService noticeService;
     private final FirebaseCloudMessageService firebaseCloudMessageService;
+    private final DeviceTokenService deviceTokenService;
 
     @Autowired
-    public NoticeController(NoticeService noticeService, FirebaseCloudMessageService firebaseCloudMessageService) {
+    public NoticeController(NoticeService noticeService, FirebaseCloudMessageService firebaseCloudMessageService, DeviceTokenService deviceTokenService) {
         this.noticeService = noticeService;
         this.firebaseCloudMessageService = firebaseCloudMessageService;
+        this.deviceTokenService = deviceTokenService;
     }
 
     /**
@@ -47,7 +53,14 @@ public class NoticeController {
             noticeService.createNotice(reqDTO.getTitle(), reqDTO.getContent());
 
             // FCM 보내기
-            // firebaseCloudMessageService.sendMessageTo(,"[공지사항 업데이트]", "공지사항이 업데이트 되었습니다.", 1);
+            try {
+                List<String> deviceTokens = deviceTokenService.findAllDeviceTokens_noticeFlag1();
+                firebaseCloudMessageService.sendMessageTo(deviceTokens, "[공지사항 업데이트]", "공지사항이 업데이트 되었습니다.");
+                log.info("[FCM 전송 성공] notice_flag가 1인 모든 사용자에게, 공지사항 FCM 전송 성공");
+            }
+            catch (BaseException e){
+                log.error("[FCM 전송 실패] " + e.getStatus());
+            }
 
             return new BaseResponse<>("성공적으로 새로운 공지사항을 생성했습니다.");
         }

--- a/src/main/java/com/planz/planit/src/domain/deviceToken/DeviceTokenRepository.java
+++ b/src/main/java/com/planz/planit/src/domain/deviceToken/DeviceTokenRepository.java
@@ -32,4 +32,7 @@ public interface DeviceTokenRepository extends JpaRepository<DeviceToken,Long> {
 
     @Query(value = "CALL run_away();", nativeQuery = true)
     List<DeviceToken> callRunAwayProcedure();
+
+    @Query(value = "select d.deviceToken from DeviceToken d where d.noticeFlag = 1")
+    List<String> findAllDeviceTokens_noticeFlag1();
 }

--- a/src/main/java/com/planz/planit/src/service/DeviceTokenService.java
+++ b/src/main/java/com/planz/planit/src/service/DeviceTokenService.java
@@ -12,6 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.Collections;
 import java.util.List;
 
 import static com.planz.planit.config.BaseResponseStatus.DATABASE_ERROR;
@@ -112,6 +113,20 @@ public class DeviceTokenService {
             log.error("callRunAwayProcedure() : deviceTokenRepository.callRunAwayProcedure() 실행 중 데이터베이스 에러 발생");
             e.printStackTrace();
         }
-        return null;
+        return Collections.emptyList();
+    }
+
+    /**
+     * notice_flag가 1인 모든 사용자의 deviceToken 리스트 조회
+     */
+    public List<String> findAllDeviceTokens_noticeFlag1(){
+        try{
+            return deviceTokenRepository.findAllDeviceTokens_noticeFlag1();
+        }
+        catch (Exception e){
+            log.error("findAllDeviceTokens_noticeFlag1() : deviceTokenRepository.findAllDeviceTokens_noticeFlag1() 실행 중 데이터베이스 에러 발생");
+            e.printStackTrace();
+        }
+        return Collections.emptyList();
     }
 }

--- a/src/main/java/com/planz/planit/src/service/MailService.java
+++ b/src/main/java/com/planz/planit/src/service/MailService.java
@@ -34,6 +34,7 @@ public class MailService {
         }
         catch (Exception e){
             log.error("mailSend() : javaMailSender.send(message) 실행 중 에러 발생");
+            e.printStackTrace();
             throw new BaseException(MAIL_SEND_ERROR);
         }
     }


### PR DESCRIPTION
### 1. 가출 FCM 코드 추가
* 매일밤 12시, **setting_flag가 1**이고 **가출 상태**인 모든 사용자에게 `가출 FCM 전송`

### 2. 공지사항 FCM 코드 추가
* 공지사항 생성 API 호출 시, **notice_flag가 1**인 모든 사용자에게 `공지사항 FCM 전송`

### 3. 메일 전송 에러 해결
* 구글 보안 정책 문제로 인해, 앱 비밀번호 생성으로 해결 