### PR TITLE
친구 검색 DTO 수정

### DIFF
--- a/src/main/java/com/planz/planit/src/apicontroller/GoalController.java
+++ b/src/main/java/com/planz/planit/src/apicontroller/GoalController.java
@@ -99,10 +99,10 @@ public class GoalController {
 
     @GetMapping("/goals/users")
     @ApiOperation("그룹 목표 닉네임 검색 api")
-    public BaseResponse<GoalSearchUserResDTO> goalSearchUser(HttpServletRequest request, @RequestParam("nickname") String nickname) {
+    public BaseResponse<List<GoalSearchUserResDTO>> goalSearchUser(HttpServletRequest request, @RequestParam("nickname") String nickname) {
         Long userId = Long.valueOf(request.getHeader(USER_ID_HEADER_NAME)).longValue();
         try {
-            GoalSearchUserResDTO resDTO = goalService.goalSearchUser(userId, nickname);
+            List<GoalSearchUserResDTO> resDTO = goalService.goalSearchUser(userId, nickname);
             return new BaseResponse<>(resDTO);
         } catch (BaseException e) {
             return new BaseResponse<>(e.getStatus());

--- a/src/main/java/com/planz/planit/src/domain/friend/FriendRepository.java
+++ b/src/main/java/com/planz/planit/src/domain/friend/FriendRepository.java
@@ -19,4 +19,9 @@ public interface FriendRepository extends JpaRepository<Friend,Long> {
     public List<Friend> findByToUser(Long userId);
 
     boolean existsByFromUserAndToUserAndFriendStatus(User fromUser, User toUser, FriendStatus friendStatus);
+
+    @Query(value="select f from Friend f where f.toUser.userId = :userId and f.friendStatus='FRIEND' and f.fromUser.nickname like %:nickname%")
+    List<Friend> seachFriendsByToUser(Long userId, String nickname);
+    @Query(value="select f from Friend f where f.fromUser.userId = :userId and f.friendStatus='FRIEND' and f.toUser.nickname like %:nickname%")
+    List<Friend> seachFriendsByFromUser(Long userId, String nickname);
 }

--- a/src/main/java/com/planz/planit/src/service/FriendService.java
+++ b/src/main/java/com/planz/planit/src/service/FriendService.java
@@ -135,4 +135,21 @@ public class FriendService {
             throw new BaseException(DATABASE_ERROR);
         }
     }
+
+    //닉네임으로 유저 검색
+    public List<User> getSearchFriends(Long userId, String nickname) throws BaseException {
+
+        List<Friend> toFriends = friendRepository.seachFriendsByToUser(userId,nickname);
+        List<Friend> fromFriends = friendRepository.seachFriendsByFromUser(userId,nickname);
+
+        if(toFriends.isEmpty() && fromFriends.isEmpty()){
+            throw new BaseException(NOT_EXIST_FRIEND);
+        }
+        List<User> fromUserList = toFriends.stream().map(s -> s.getFromUser()).collect(Collectors.toList());
+        List<User> toUserList = fromFriends.stream().map(s -> s.getToUser()).collect(Collectors.toList());
+
+        fromUserList.addAll(toUserList);
+
+        return fromUserList;
+    }
 }

--- a/src/main/java/com/planz/planit/src/service/GoalService.java
+++ b/src/main/java/com/planz/planit/src/service/GoalService.java
@@ -213,16 +213,15 @@ public class GoalService {
      * @param nickname
      * @return
      */
-    public GoalSearchUserResDTO goalSearchUser(Long userId, String nickname) throws BaseException {
+    public List<GoalSearchUserResDTO> goalSearchUser(Long userId, String nickname) throws BaseException {
         //검색하려는 친구 DTO 가져오기
-        GoalSearchUserResDTO findUserDTO = userService.goalSearchUsers(nickname);
-        //친구인지 확인하기
-        User user = userService.findUser(userId);
-        User findUser = userService.findUser(findUserDTO.getUserId());
-        if(!friendService.isFriend(user,findUser)){
-            throw new BaseException(NOT_EXIST_FRIEND);
+        List<User> friends = friendService.getSearchFriends(userId,nickname);
+
+        List<GoalSearchUserResDTO> responses = new ArrayList<>();
+        for (User user : friends) {
+            responses.add(new GoalSearchUserResDTO(user.getUserId(),user.getNickname(),user.getProfileColor().toString()));
         }
-        return findUserDTO;
+        return responses;
     }
 
     //setter에서 생성자로 수정 필요


### PR DESCRIPTION
### 그룹 목표 생성 시 친구 검색 API 수정
- 해당 닉네임을 가진 유저를 반환하는 로직에서 
- 닉네임을 포함하는 유저리스트를 반환하는 로직으로 수정했습니다.

- 유저를 검색하고 친구인지 확인 -> 친구 테이블 내에서 검색하는 방식으로 수정