### PR TITLE
운영자 매일 미션 스케줄러 등록 & 행성 메인 화면 조회 API response 수정

### DIFF
--- a/src/main/java/com/planz/planit/config/batch/BatchConfig.java
+++ b/src/main/java/com/planz/planit/config/batch/BatchConfig.java
@@ -4,7 +4,6 @@ import com.planz.planit.config.BaseException;
 import com.planz.planit.config.fcm.FirebaseCloudMessageService;
 import com.planz.planit.src.domain.deviceToken.DeviceToken;
 import com.planz.planit.src.service.DeviceTokenService;
-import com.planz.planit.src.service.UserService;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
@@ -18,7 +17,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import java.util.List;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Log4j2
@@ -28,20 +26,21 @@ public class BatchConfig {
 
     private final JobBuilderFactory jobBuilderFactory;
     private final StepBuilderFactory stepBuilderFactory;
-    private final UserService userService;
     private final DeviceTokenService deviceTokenService;
     private final FirebaseCloudMessageService firebaseCloudMessageService;
 
 
     @Autowired
-    public BatchConfig(JobBuilderFactory jobBuilderFactory, StepBuilderFactory stepBuilderFactory, UserService userService, DeviceTokenService deviceTokenService, FirebaseCloudMessageService firebaseCloudMessageService) {
+    public BatchConfig(JobBuilderFactory jobBuilderFactory, StepBuilderFactory stepBuilderFactory, DeviceTokenService deviceTokenService, FirebaseCloudMessageService firebaseCloudMessageService) {
         this.jobBuilderFactory = jobBuilderFactory;
         this.stepBuilderFactory = stepBuilderFactory;
-        this.userService = userService;
         this.deviceTokenService = deviceTokenService;
         this.firebaseCloudMessageService = firebaseCloudMessageService;
     }
 
+    /**
+     * 가출
+     */
     @Bean
     public Job jobRunAway(){
         Job jobRunAway = jobBuilderFactory.get("jobRunAway")
@@ -78,6 +77,48 @@ public class BatchConfig {
                 .build();
         return stepCallRunAwayProcedure;
     }
+
+
+    /**
+     * 운영자 매일 미션
+      */
+    @Bean
+    public Job jobMission(){
+        Job jobMission = jobBuilderFactory.get("jobMission")
+                .start(stepCallMissionProcedure())
+                .build();
+        return jobMission;
+    }
+
+    @Bean
+    @JobScope
+    public Step stepCallMissionProcedure(){
+        Step stepCallMissionProcedure = stepBuilderFactory.get("stepCallMissionProcedure")
+                .tasklet((contribution, chunkContext) -> {
+                    log.info("stepCallMissionProcedure : 운영자 매일 미션 프로시저(mission) 실행");
+
+                    // MySQL의 운영자 매일 미션 프로시저 (mission) 실행
+                    List<DeviceToken> deviceTokenList = deviceTokenService.callMissionProcedure();
+                    // setting_flag가 1이고, 사용자 매일 미션을 받는 사용자의 deviceToken 값 리스트
+                    List<String> deviceTokens = deviceTokenList.stream()
+                            .map(DeviceToken::getDeviceToken)
+                            .collect(Collectors.toList());
+
+                    try{
+                        // push 알림 전송
+                        firebaseCloudMessageService.sendMessageTo(deviceTokens, "[운영자 매일 미션]", "행성의 성장을 돕기위한 오늘의 미션이 도착했습니다.");
+                        log.info("[FCM 전송 성공] setting_flag가 1이고 운영자 매일 미션을 받는 사용자에게, 운영자 매일 미션 FCM 전송 성공");
+                    }
+                    catch (BaseException e){
+                        log.error("[FCM 전송 실패] " + e.getStatus());
+                    }
+
+                    return RepeatStatus.FINISHED;
+                })
+                .build();
+        return stepCallMissionProcedure;
+    }
+
 
 }
 

--- a/src/main/java/com/planz/planit/config/batch/BatchScheduler.java
+++ b/src/main/java/com/planz/planit/config/batch/BatchScheduler.java
@@ -28,6 +28,7 @@ public class BatchScheduler {
         this.batchConfig = batchConfig;
     }
 
+    // 가출 스케줄러
     //초 분 시 일 월 요일
     @Scheduled(cron = "0 0 0 * * *")
     public void runJob(){
@@ -41,6 +42,25 @@ public class BatchScheduler {
         catch (JobExecutionAlreadyRunningException | JobInstanceAlreadyCompleteException
                 | JobParametersInvalidException | JobRestartException e){
             log.error("스프링 가출 배치 실행중 에러 발생");
+            e.printStackTrace();
+        }
+    }
+
+    // 운영자 매일 미션 스케줄러
+    //초 분 시 일 월 요일
+    @Scheduled(cron = "0 0 0 * * *")
+    public void missionJob(){
+        log.info("운영자 매일 미션 스케줄러 실행");
+        Map<String, JobParameter> confMap = new HashMap<>();
+        confMap.put("time", new JobParameter(System.currentTimeMillis()));
+        JobParameters jobParameters = new JobParameters(confMap);
+
+        try{
+            jobLauncher.run(batchConfig.jobMission(), jobParameters);
+        }
+        catch (JobExecutionAlreadyRunningException | JobInstanceAlreadyCompleteException
+                | JobParametersInvalidException | JobRestartException e){
+            log.error("스프링 운영자 매일 미션 배치 실행중 에러 발생");
             e.printStackTrace();
         }
     }

--- a/src/main/java/com/planz/planit/src/domain/deviceToken/DeviceToken.java
+++ b/src/main/java/com/planz/planit/src/domain/deviceToken/DeviceToken.java
@@ -2,6 +2,7 @@ package com.planz.planit.src.domain.deviceToken;
 
 import com.planz.planit.src.domain.friend.FriendStatus;
 import com.planz.planit.src.domain.user.User;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,6 +17,7 @@ import static java.time.LocalDateTime.now;
 @Getter
 @Entity
 @NoArgsConstructor
+@AllArgsConstructor
 @Table(
         uniqueConstraints = {
                 @UniqueConstraint(

--- a/src/main/java/com/planz/planit/src/domain/deviceToken/DeviceTokenRepository.java
+++ b/src/main/java/com/planz/planit/src/domain/deviceToken/DeviceTokenRepository.java
@@ -30,8 +30,13 @@ public interface DeviceTokenRepository extends JpaRepository<DeviceToken,Long> {
     @Query("select d.deviceTokenId from DeviceToken d where d.user.userId = :userId")
     List<Long> findAllByUserIdInQuery(@Param("userId") Long userId);
 
+    // 가출 프로시저 호출
     @Query(value = "CALL run_away();", nativeQuery = true)
     List<DeviceToken> callRunAwayProcedure();
+
+    // 운영자 매일 미션 프로시저 호출
+    @Query(value = "CALL mission();", nativeQuery = true)
+    List<DeviceToken> callMissionProcedure();
 
     @Query(value = "select d.deviceToken from DeviceToken d where d.noticeFlag = 1")
     List<String> findAllDeviceTokens_noticeFlag1();

--- a/src/main/java/com/planz/planit/src/domain/mission/Mission.java
+++ b/src/main/java/com/planz/planit/src/domain/mission/Mission.java
@@ -1,0 +1,23 @@
+package com.planz.planit.src.domain.mission;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+public class Mission {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "mission_id")
+    private Long id;
+
+    private String content;
+}

--- a/src/main/java/com/planz/planit/src/domain/planet/dto/GetPlanetMainInfoResDTO.java
+++ b/src/main/java/com/planz/planit/src/domain/planet/dto/GetPlanetMainInfoResDTO.java
@@ -19,6 +19,9 @@ public class GetPlanetMainInfoResDTO {
     // 행성 레벨
     private Integer level;
 
+    // 전날 투두 완료 퍼센테이지 = 전날 목표량
+    private Integer prePercent;
+
     // 캐릭터 가출 여부
     private Boolean isRunAway;
 

--- a/src/main/java/com/planz/planit/src/service/DeviceTokenService.java
+++ b/src/main/java/com/planz/planit/src/service/DeviceTokenService.java
@@ -129,6 +129,20 @@ public class DeviceTokenService {
     }
 
     /**
+     * 운영자 매일 미션 프로시저 호출
+     */
+    public List<DeviceToken> callMissionProcedure(){
+        try{
+            return deviceTokenRepository.callMissionProcedure();
+        }
+        catch (Exception e){
+            log.error("callMissionProcedure() : deviceTokenRepository.callMissionProcedure() 실행 중 데이터베이스 에러 발생");
+            e.printStackTrace();
+        }
+        return Collections.emptyList();
+    }
+
+    /**
      * notice_flag가 1인 모든 사용자의 deviceToken 리스트 조회
      */
     public List<String> findAllDeviceTokens_noticeFlag1(){

--- a/src/main/java/com/planz/planit/src/service/PlanetService.java
+++ b/src/main/java/com/planz/planit/src/service/PlanetService.java
@@ -123,6 +123,7 @@ public class PlanetService {
                     .userId(targetUserId)
                     .planetColor(planet.getColor().name())
                     .level(planet.getLevel())
+                    .prePercent(user.getPrevPercent())
                     .isRunAway(isRunAway)
                     .characterItem(user.getCharacterItem())
                     .planetItemList(planetItemList)


### PR DESCRIPTION
1. 행성 메인 화면 조회 API에서 prePercent (전날 투두 완료 퍼센테이지) 반환
2. 스프링 배치 및 스케줄러를 통해, 매일밤 12시에 mission 프로시저 호출 및 FCM 전송
3. DB 테이블에 운영자 매일 미션 목록 추가 & mission 프로시저 리펙토링